### PR TITLE
inhibit transfers when checksums are being computed

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 0.3.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Inhibit transfers when checksums are being computed at KPNO (PR `#7`_).
+
+.. _`#7`: https://github.com/desihub/desitransfer/pull/7
+
 
 0.3.1 (2019-09-12)
 ------------------

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -175,6 +175,8 @@ The DESI Collaboration Account
     def transfer(self):
         """Loop over and transfer all configured directories.
         """
+        if self.checksum_lock():
+            return
         for d in self.directories:
             log.info('Looking for new data in %s.', d.source)
             try:
@@ -182,6 +184,22 @@ The DESI Collaboration Account
             except Exception as e:
                 log.critical("Exception detected in transfer of %s!\n\n%s",
                              d.source, traceback.format_exc())
+
+    def checksum_lock(self):
+        """See if checksums are being computed at KPNO.
+
+        Returns
+        -------
+        :class:`bool`
+            ``True`` if checksums are being computed.
+        """
+        cmd = [self.conf['pipeline']['ssh'], '-q', 'dts',
+               '/bin/ls', self.conf['common']['checksum_lock']]
+        _, out, err = _popen(cmd)
+        if out:
+            log.info('Checksums are being computed at KPNO.')
+            return True
+        return False
 
     def directory(self, d):
         """Data transfer operations for a single destination directory.

--- a/py/desitransfer/data/desi_transfer_daemon.ini
+++ b/py/desitransfer/data/desi_transfer_daemon.ini
@@ -23,6 +23,8 @@ checksum_file = checksum-{night}-{exposure}.sha256sum
 # Use this directory for temporary files.
 scratch = ${CSCRATCH}
 # scratch = ${HOME}/tmp
+# The presence of this file indicates checksums are being computed.
+checksum_lock = /tmp/checksum-running
 # UTC time in hours to look for delayed files.
 # Disable this with an invalid hour, e.g. 30.
 catchup = 14

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -167,7 +167,11 @@ class TestDaemon(unittest.TestCase):
             d = TransferDaemon(options)
         mock_lock.return_value = True
         d.transfer()
-        mock_lock.assert_called_once()
+        try:
+            mock_lock.assert_called_once()
+        except AttributeError:
+            # Python 3.5 doesn't have this.
+            pass
         mock_lock.return_value = False
         d.transfer()
         mock_log.info.assert_called_once_with('Looking for new data in %s.',

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -151,10 +151,11 @@ class TestDaemon(unittest.TestCase):
         gl.assert_called_once_with(timestamp=True)
         ll.setLevel.assert_called_once_with(logging.DEBUG)
 
+    @patch.object(TransferDaemon, 'checksum_lock')
     @patch.object(TransferDaemon, 'directory')
     @patch('desitransfer.daemon.log')
     @patch.object(TransferDaemon, '_configure_log')
-    def test_TransferDaemon_transfer(self, mock_cl, mock_log, mock_dir):
+    def test_TransferDaemon_transfer(self, mock_cl, mock_log, mock_dir, mock_lock):
         """Test loop over all configured directories.
         """
         with patch.dict('os.environ',
@@ -164,6 +165,10 @@ class TestDaemon(unittest.TestCase):
             with patch.object(sys, 'argv', ['desi_transfer_daemon', '--debug']):
                 options = _options()
             d = TransferDaemon(options)
+        mock_lock.return_value = True
+        d.transfer()
+        mock_lock.assert_called_once()
+        mock_lock.return_value = False
         d.transfer()
         mock_log.info.assert_called_once_with('Looking for new data in %s.',
                                               d.directories[0].source)
@@ -175,6 +180,25 @@ class TestDaemon(unittest.TestCase):
         except AttributeError:
             # Python 3.5 doesn't have this.
             pass
+
+    @patch('desitransfer.daemon._popen')
+    @patch('desitransfer.daemon.log')
+    @patch.object(TransferDaemon, '_configure_log')
+    def test_TransferDaemon_checksum_lock(self, mock_cl, mock_log, mock_popen):
+        """Test checksum locking mechanism.
+        """
+        with patch.dict('os.environ',
+                        {'CSCRATCH': self.tmp.name,
+                         'DESI_ROOT': '/desi/root',
+                         'DESI_SPECTRO_DATA': '/desi/root/spectro/data'}):
+            with patch.object(sys, 'argv', ['desi_transfer_daemon', '--debug']):
+                options = _options()
+            d = TransferDaemon(options)
+        mock_popen.return_value = ('0', '/tmp/checksum-running', '')
+        self.assertTrue(d.checksum_lock())
+        mock_log.info.assert_called_once_with('Checksums are being computed at KPNO.')
+        mock_popen.return_value = ('2', '', 'No such file.')
+        self.assertFalse(d.checksum_lock())
 
     @patch.object(TransferDaemon, 'backup')
     @patch.object(TransferDaemon, 'catchup')

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, call, mock_open
 from ..daily import _config, _options, DailyDirectory
 from .. import __version__ as dtVersion
 
+
 class TestDaily(unittest.TestCase):
     """Test desitransfer.daily.
     """


### PR DESCRIPTION
This PR adds a locking mechanism to inhibit data transfers while after-the-fact checksums are being computed.  This is not ironclad protection, but it should prevent files from being transferred while being written out in most cases.