### PR TITLE
More careful status file handling

### DIFF
--- a/bin/desi_transfer_status_restore
+++ b/bin/desi_transfer_status_restore
@@ -1,26 +1,62 @@
 #!/usr/bin/env python
+"""
+Quick and dirty script to restore raw data transfer status.
+
+1. Obtain rsync time from modification time of exposure directory.
+2. Set checksum time to rsync time.
+3. Ignore pipeline time.
+4. Obtain backup time from HPSS backup files.
+
+This script is deliberately kept separate from the package because it
+uses hpsspy.
+"""
 from sys import exit
+import json
 import os
-import subprocess as sub
 import hpsspy.os as hpos
 
+
 def backup_times(path='desi/spectro/data'):
+    """Obtain backup times from HPSS files.
+
+    Parameters
+    ----------
+    path : :class:`str`
+        The HPSS path to the raw data backup files.
+
+    Returns
+    -------
+    :class:`dict`
+        A mapping of night to backup time.  The backup time is in milliseconds
+        for compatibility with JavaScript.
+    """
     ls = hpos.listdir(path)
-    return dict([(os.path.splitext(.name)[0].split('_')[-1], f.st_mtime*1000)
+    return dict([(os.path.splitext(f.name)[0].split('_')[-1], f.st_mtime*1000)
                  for f in ls if f.name.endswith('.tar')])
 
 
 def main():
+    """Entry point for :command:`desi_transfer_status_restore`.
+
+    Returns
+    -------
+    :class:`int`
+        An integer suitable for passing to :func:`sys.exit`.
+    """
     bt = backup_times()
     nights = os.listdir(os.environ['DESI_SPECTRO_DATA'])
     status = list()
     for night in nights:
-        exposures = os.listdir(os.path.join(os.environ['DESI_SPECTRO_DATA'], night))
-        for exp in exposures:
-            rt = int(os.stat(os.path.join(os.environ['DESI_SPECTRO_DATA'], night, exp)).st_mtime * 1000)
-            status.append([int(night), int(exp), 'rsync', True, '', rt])
-            status.append([int(night), int(exp), 'checksum', True, '', rt])
-            status.append([int(night), int(exp), 'backup', True, '', bt[night]])
+        if night != 'README.html':
+            exposures = os.listdir(os.path.join(os.environ['DESI_SPECTRO_DATA'], night))
+            for exp in exposures:
+                rt = int(os.stat(os.path.join(os.environ['DESI_SPECTRO_DATA'], night, exp)).st_mtime * 1000)
+                status.append([int(night), int(exp), 'rsync', True, '', rt])
+                status.append([int(night), int(exp), 'checksum', True, '', rt])
+                try:
+                    status.append([int(night), int(exp), 'backup', True, '', bt[night]])
+                except KeyError:
+                    pass
     status = sorted(status, key=lambda x: x[0]*10000000 + x[1], reverse=True)
     with open('desi_transfer_status_restore.json', 'w') as j:
         json.dump(status, j, indent=None, separators=(',', ':'))

--- a/bin/desi_transfer_status_restore
+++ b/bin/desi_transfer_status_restore
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from sys import exit
+import os
+import subprocess as sub
+import hpsspy.os as hpos
+
+def backup_times(path='desi/spectro/data'):
+    ls = hpos.listdir(path)
+    return dict([(os.path.splitext(.name)[0].split('_')[-1], f.st_mtime*1000)
+                 for f in ls if f.name.endswith('.tar')])
+
+
+def main():
+    bt = backup_times()
+    nights = os.listdir(os.environ['DESI_SPECTRO_DATA'])
+    status = list()
+    for night in nights:
+        exposures = os.listdir(os.path.join(os.environ['DESI_SPECTRO_DATA'], night))
+        for exp in exposures:
+            rt = int(os.stat(os.path.join(os.environ['DESI_SPECTRO_DATA'], night, exp)).st_mtime * 1000)
+            status.append([int(night), int(exp), 'rsync', True, '', rt])
+            status.append([int(night), int(exp), 'checksum', True, '', rt])
+            status.append([int(night), int(exp), 'backup', True, '', bt[night]])
+    status = sorted(status, key=lambda x: x[0]*10000000 + x[1], reverse=True)
+    with open('desi_transfer_status_restore.json', 'w') as j:
+        json.dump(status, j, indent=None, separators=(',', ':'))
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        foo = os.environ['HPSS_DIR']
+    except KeyError:
+        os.environ['HPSS_DIR'] = '/usr/common/mss'
+    exit(main())

--- a/bin/desi_transfer_status_restore
+++ b/bin/desi_transfer_status_restore
@@ -4,7 +4,7 @@ Quick and dirty script to restore raw data transfer status.
 
 1. Obtain rsync time from modification time of exposure directory.
 2. Set checksum time to rsync time.
-3. Ignore pipeline time.
+3. Ignore pipeline time (as of early 2020).
 4. Obtain backup time from HPSS backup files.
 
 This script is deliberately kept separate from the package because it

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,6 +5,9 @@ desitransfer API
 .. automodule:: desitransfer
     :members:
 
+.. automodule:: desitransfer.common
+    :members:
+
 .. automodule:: desitransfer.daemon
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 0.3.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Guard against corrupted status JSON files; restore transfer status;
+  additional daily transfers (PR `#10`_).
+
+.. _`#10`: https://github.com/desihub/desitransfer/pull/10
 
 0.3.3 (2019-12-18)
 ------------------

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -98,6 +98,8 @@ def _config():
             #                os.path.join(engineering, 'fxc')),
             DailyDirectory('/data/focalplane/logs/calib_logs',
                            os.path.join(engineering, 'focalplane', 'logs', 'calib_logs')),
+            DailyDirectory('/data/focalplane/logs/kpno',
+                           os.path.join(engineering, 'focalplane', 'logs', 'kpno')),
             DailyDirectory('/data/focalplane/logs/xytest_data',
                            os.path.join(engineering, 'focalplane', 'logs', 'xytest_data')),
             DailyDirectory('/data/fvc/data',

--- a/py/desitransfer/status.py
+++ b/py/desitransfer/status.py
@@ -66,12 +66,12 @@ class TransferStatus(object):
             # If the status code is running stand-alone, the log object
             # will be None.
             print("ERROR: " + (m % (self.json, bad)))
-        m = "shutil.copy('%s', '%s')"
+        m = "shutil.copy2('%s', '%s')"
         try:
             log.debug(m, self.json, bad)
         except AttributeError:
             print("DEBUG: " + (m % (self.json, bad)))
-        shutil.copy(self.json, bad)
+        shutil.copy2(self.json, bad)
         m = "Writing empty array to %s."
         try:
             log.info(m, self.json)

--- a/py/desitransfer/status.py
+++ b/py/desitransfer/status.py
@@ -14,7 +14,6 @@ import time
 from argparse import ArgumentParser
 from pkg_resources import resource_filename
 from . import __version__ as dtVersion
-from .daemon import log
 
 
 class TransferStatus(object):
@@ -58,6 +57,7 @@ class TransferStatus(object):
         This function will save the malformed file to a .bad file for
         later analysis, and write an empty array to a new status file.
         """
+        from .daemon import log
         bad = self.json + '.bad'
         m = "Malformed JSON file detected: %s; saving original file as %s."
         try:

--- a/py/desitransfer/status.py
+++ b/py/desitransfer/status.py
@@ -121,6 +121,14 @@ class TransferStatus(object):
             self.status.insert(0, row)
         self.status = sorted(self.status, key=lambda x: x[0]*10000000 + x[1],
                              reverse=True)
+        #
+        # Copy the original file before modifying.
+        # This will overwrite any existing .bak file
+        #
+        try:
+            shutil.copy2(self.json, self.json + '.bak')
+        except FileNotFoundError:
+            pass
         with open(self.json, 'w') as j:
             json.dump(self.status, j, indent=None, separators=(',', ':'))
 

--- a/py/desitransfer/test/t/bad.json
+++ b/py/desitransfer/test/t/bad.json
@@ -1,0 +1,1 @@
+This is a bad JSON file!

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -135,10 +135,10 @@ class TestDaemon(unittest.TestCase):
     @patch('desitransfer.daemon.SMTPHandler')
     @patch('desitransfer.daemon.RotatingFileHandler')
     @patch('desitransfer.daemon.get_logger')
-    def test_TransferDaemon_configure_log(self, gl, rfh, smtp):
+    @patch('desitransfer.daemon.log')  # Needed to restore the module-level log object after test.
+    def test_TransferDaemon_configure_log(self, mock_log, gl, rfh, smtp):
         """Test logging configuration.
         """
-        ll = gl.return_value = MagicMock()
         with patch.dict('os.environ',
                         {'CSCRATCH': self.tmp.name,
                          'DESI_ROOT': '/desi/root',
@@ -149,7 +149,7 @@ class TestDaemon(unittest.TestCase):
         rfh.assert_called_once_with('/desi/root/spectro/staging/logs/desi_transfer_daemon.log',
                                     backupCount=100, maxBytes=100000000)
         gl.assert_called_once_with(timestamp=True)
-        ll.setLevel.assert_called_once_with(logging.DEBUG)
+        gl().setLevel.assert_called_once_with(logging.DEBUG)
 
     @patch.object(TransferDaemon, 'checksum_lock')
     @patch.object(TransferDaemon, 'directory')

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -110,7 +110,7 @@ class TestDaily(unittest.TestCase):
                              call().__exit__(None, None, None)])
         mock_popen.assert_has_calls([call(),
                                      call(['fix_permissions.sh', '-a', '/dst/d0'],
-                                          stdout=mo(), stderr=-2), 
+                                          stdout=mo(), stderr=-2),
                                      call().wait()])
 
 

--- a/py/desitransfer/test/test_status.py
+++ b/py/desitransfer/test/test_status.py
@@ -101,7 +101,7 @@ class TestStatus(unittest.TestCase):
         mock_log.error.assert_called_once_with('Malformed JSON file detected: %s; saving original file as %s.',
                                                os.path.join(d, 'desi_transfer_status.json'),
                                                os.path.join(d, 'desi_transfer_status.json.bad'))
-        mock_log.debug.assert_called_once_with("shutil.copy('%s', '%s')",
+        mock_log.debug.assert_called_once_with("shutil.copy2('%s', '%s')",
                                                os.path.join(d, 'desi_transfer_status.json'),
                                                os.path.join(d, 'desi_transfer_status.json.bad'))
         mock_log.info.assert_called_once_with('Writing empty array to %s.',
@@ -121,8 +121,8 @@ class TestStatus(unittest.TestCase):
                                                  'desi_transfer_status.json'])
         mock_print.assert_has_calls([call('ERROR: Malformed JSON file detected: %s; saving original file as %s.' % (os.path.join(d, 'desi_transfer_status.json'),
                                                                                                                     os.path.join(d, 'desi_transfer_status.json.bad'))),
-                                     call("DEBUG: shutil.copy('%s', '%s')" % (os.path.join(d, 'desi_transfer_status.json'),
-                                                                              os.path.join(d, 'desi_transfer_status.json.bad'))),
+                                     call("DEBUG: shutil.copy2('%s', '%s')" % (os.path.join(d, 'desi_transfer_status.json'),
+                                                                               os.path.join(d, 'desi_transfer_status.json.bad'))),
                                      call("INFO: Writing empty array to %s." % (os.path.join(d, 'desi_transfer_status.json'),))])
 
     @patch('time.time')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools
 pytz
-git+https://github.com/desihub/desiutil.git@1.9.15#egg=desiutil
+git+https://github.com/desihub/desiutil.git@2.0.1#egg=desiutil


### PR DESCRIPTION
This PR:

* Fixes #9 
  - If the status file is corrupted, start fresh with a new file, but save a copy of the corrupted one for analysis.
  - In normal operations, save a backup copy of the file before each update.
  - A new script `desi_transfer_status_restore` can approximately recover from lost status data.  See the script itself for the assumptions used in the recovery.
* Adds an additional daily transfer directory.