### PR TITLE
Remove Apache ACL option

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,10 @@ Change Log
 ------------------
 
 * Updates to Tucson transfer script (PR `#14`_).
+* Remove Apache ACL option (PR `#15`_).
 
 .. _`#14`: https://github.com/desihub/desitransfer/pull/14
+.. _`#15`: https://github.com/desihub/desitransfer/pull/15
 
 0.3.6 (2020-03-19)
 ------------------

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -77,7 +77,7 @@ class DailyDirectory(object):
         :class:`int`
             The status returned by :command:`fix_permissions.sh`.
         """
-        cmd = ['fix_permissions.sh', '-a', self.destination]
+        cmd = ['fix_permissions.sh', self.destination]
         with open(self.log, 'ab') as l:
             l.write(("DEBUG: %s\n" % ' '.join(cmd)).encode('utf-8'))
             l.flush()

--- a/py/desitransfer/nightwatch.py
+++ b/py/desitransfer/nightwatch.py
@@ -205,8 +205,8 @@ def main():
         #
         if options.apache:
             if os.path.exists(nightdir):
-                log.info('Fixing permissions for Apache.')
-                cmd = ['fix_permissions.sh', '-a', nightdir]
+                log.info('Fixing permissions for DESI.')
+                cmd = ['fix_permissions.sh', nightdir]
                 status, out, err = _popen(cmd)
                 if status != '0':
                     errcount += 1

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -106,11 +106,11 @@ class TestDaily(unittest.TestCase):
         d.apache()
         mo.assert_has_calls([call('/dst/d0.log', 'ab'),
                              call().__enter__(),
-                             call().write(b'DEBUG: fix_permissions.sh -a /dst/d0\n'),
+                             call().write(b'DEBUG: fix_permissions.sh /dst/d0\n'),
                              call().flush(),
                              call().__exit__(None, None, None)])
         mock_popen.assert_has_calls([call(),
-                                     call(['fix_permissions.sh', '-a', '/dst/d0'],
+                                     call(['fix_permissions.sh', '/dst/d0'],
                                           stdout=mo(), stderr=-2),
                                      call().wait()])
 


### PR DESCRIPTION
Since we are no longer distribution data via portal.nersc.gov, we no longer need to set Apache ACL on data transferred by desitransfer.