### PR TITLE
Daily nightwatch transfer

### DIFF
--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -33,7 +33,7 @@ static='protodesi public/epo public/ets spectro/redux/andes spectro/redux/minisv
 #
 # Dynamic data sets may change daily.
 #
-dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
+dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
 #
 # Get options.
 #
@@ -98,7 +98,7 @@ for d in ${dynamic}; do
     # Check for subdirectories to include.
     #
     case ${d} in
-        spectro/nightwatch) inc="--exclude dev/*** --exclude preproc*.fits --exclude qsky*.fits --exclude *.tmp" ;;
+        # spectro/nightwatch) inc="--exclude dev/*** --exclude preproc*.fits --exclude qsky*.fits --exclude *.tmp" ;;
         # spectro/redux) inc="--include oak1/*** --include daily/*** --exclude *" ;;
         *) inc='' ;;
     esac

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -29,11 +29,11 @@ set -o noglob
 #
 # Static data sets don't need to be updated as frequently.
 #
-static='protodesi public/ets spectro/redux/andes spectro/redux/minisv2 spectro/redux/oak1'
+static='protodesi public/epo public/ets spectro/redux/andes spectro/redux/minisv2 spectro/redux/oak1'
 #
 # Dynamic data sets may change daily.
 #
-dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
+dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
 #
 # Get options.
 #
@@ -98,7 +98,7 @@ for d in ${dynamic}; do
     # Check for subdirectories to include.
     #
     case ${d} in
-        # spectro/nightwatch) inc="--include kpno/*** --exclude *" ;;
+        spectro/nightwatch) inc="--exclude dev/*** --exclude preproc*.fits --exclude qsky*.fits --exclude *.tmp" ;;
         # spectro/redux) inc="--include oak1/*** --include daily/*** --exclude *" ;;
         *) inc='' ;;
     esac

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -98,7 +98,7 @@ for d in ${dynamic}; do
     # Check for subdirectories to include.
     #
     case ${d} in
-        # spectro/nightwatch) inc="--exclude dev/*** --exclude preproc*.fits --exclude qsky*.fits --exclude *.tmp" ;;
+        # spectro/nightwatch) inc="--include kpno/*** --exclude *" ;;
         # spectro/redux) inc="--include oak1/*** --include daily/*** --exclude *" ;;
         *) inc='' ;;
     esac

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,12 @@ Change Log
 0.3.9 (unreleased)
 ------------------
 
-* No changes yet.
+* Deprecate continuous nightwatch transfers; nightwatch is now part of the
+  daily engineering transfer (PR `#21`_).
+* Allow alternate scratch directory to be chosen if :envvar:`CSCRATCH` is
+  unavailable (PR `#21`_).
+
+.. _`#21`: https://github.com/desihub/desitransfer/pull/21
 
 0.3.8 (2020-10-26)
 ------------------

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -81,6 +81,35 @@ def stamp(zone='US/Pacific'):
     return n.astimezone(tz).strftime('%Y-%m-%d %H:%M:%S %Z')
 
 
+def ensure_scratch(primary, alternate):
+    """Try an alternate temporary directory if the primary temporary directory
+    is unavilable.
+
+    Parameters
+    ----------
+    primary : :class:`str`
+        Primary temporary directory.
+    alternate : :class:`list`
+        A list of alternate directories.
+
+    Returns
+    -------
+    The first available temporary directory found.
+    """
+    if not isinstance(alternate, list):
+        alternate = [alternate]
+    try:
+        l = os.listdir(primary)
+    except FileNotFoundError:
+        for a in alternate:
+            try:
+                l = os.listdir(a)
+            except FileNotFoundError:
+                continue
+            return a
+    return primary
+
+
 def yesterday():
     """Yesterday's date in DESI "NIGHT" format, YYYYMMDD.
     """

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -365,7 +365,7 @@ The DESI Collaboration Account
             #
             pass
         else:
-            log.error('rsync problem detected!')
+            log.error('rsync problem detected for %s/%s!', night, exposure)
             log.debug("status.update('%s', '%s', 'rsync', failure=True)", night, exposure)
             status.update(night, exposure, 'rsync', failure=True)
 

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -24,7 +24,7 @@ from socket import getfqdn
 from tempfile import TemporaryFile
 from pkg_resources import resource_filename
 from desiutil.log import get_logger
-from .common import dir_perm, file_perm, rsync, yesterday, empty_rsync
+from .common import dir_perm, file_perm, rsync, yesterday, empty_rsync, ensure_scratch
 from .status import TransferStatus
 from . import __version__ as dtVersion
 
@@ -94,7 +94,7 @@ class TransferDaemon(object):
                                             self.conf[s].getlist('expected_files'),
                                             self.conf[s]['checksum_file'])
                             for s in self.sections]
-        self.scratch = self.conf['common']['scratch']
+        self.scratch = ensure_scratch(self.conf['common']['scratch'], self.conf['common']['alternate_scratch'].split(','))
         self._configure_log(options.debug)
         return
 

--- a/py/desitransfer/data/desi_nightwatch_transfer_exclude.txt
+++ b/py/desitransfer/data/desi_nightwatch_transfer_exclude.txt
@@ -1,3 +1,9 @@
-*/preproc*.fits
-*/qsky-*.fits
-*/*.tmp
+preproc*.fits
+qsky-*.fits
+*.tmp
+nightwatch.*
+nightwatch-debug.*
+nightwatch-webapp.*
+webapp.log
+redux
+test

--- a/py/desitransfer/data/desi_transfer_daemon.ini
+++ b/py/desitransfer/data/desi_transfer_daemon.ini
@@ -22,7 +22,7 @@ checksum_file = checksum-{exposure}.sha256sum
 [common]
 # Use this directory for temporary files.
 scratch = ${CSCRATCH}
-# scratch = ${HOME}/tmp
+alternate_scratch = ${HOME}/tmp
 # The presence of this file indicates checksums are being computed.
 checksum_lock = /tmp/checksum-running
 # UTC time in hours to look for delayed files.

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -288,7 +288,7 @@ class TestDaemon(unittest.TestCase):
         mock_popen.assert_called_once_with(['/bin/rsync', '--verbose', '--recursive',
                                             '--copy-dirlinks', '--times', '--omit-dir-times',
                                             'dts:/data/dts/exposures/raw/20190703/00000127/', '/desi/root/spectro/staging/raw/20190703/00000127/'])
-        mock_log.error.assert_called_once_with('rsync problem detected!')
+        mock_log.error.assert_called_once_with('rsync problem detected for %s/%s!', '20190703', '00000127')
         mock_status.update.assert_called_once_with('20190703', '00000127', 'rsync', failure=True)
         #
         # Actually run the pipeline

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -37,6 +37,7 @@ class TestDaily(unittest.TestCase):
             self.assertEqual(c[0].source, '/exposures/desi/sps')
             self.assertEqual(c[0].destination, os.path.join(os.environ['DESI_ROOT'],
                                                             'engineering', 'spectrograph', 'sps'))
+            self.assertEqual(c[1].extra[0], '--exclude')
 
     def test_options(self):
         """Test command-line arguments.

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -37,7 +37,8 @@ class TestDaily(unittest.TestCase):
             self.assertEqual(c[0].source, '/exposures/desi/sps')
             self.assertEqual(c[0].destination, os.path.join(os.environ['DESI_ROOT'],
                                                             'engineering', 'spectrograph', 'sps'))
-            self.assertEqual(c[1].extra[0], '--exclude')
+            self.assertEqual(c[1].extra[0], '--exclude-from')
+            self.assertTrue(c[2].dirlinks)
 
     def test_options(self):
         """Test command-line arguments.
@@ -46,7 +47,7 @@ class TestDaily(unittest.TestCase):
                           ['desi_daily_transfer', '--daemon', '--kill',
                            os.path.expanduser('~/stop_daily_transfer')]):
             options = _options()
-            self.assertTrue(options.apache)
+            self.assertTrue(options.permission)
             self.assertEqual(options.sleep, 24)
             self.assertTrue(options.daemon)
             self.assertEqual(options.kill,
@@ -70,7 +71,7 @@ class TestDaily(unittest.TestCase):
                              call().__enter__(),
                              call().write(('DEBUG: desi_daily_transfer {}\n'.format(dtVersion)).encode('utf-8')),
                              call().write(b'DEBUG: 2019-07-03\n'),
-                             call().write(b'DEBUG: /bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/src/d0/ /dst/d0/\n'),
+                             call().write(b'DEBUG: /bin/rsync --verbose --recursive --links --times --omit-dir-times dts:/src/d0/ /dst/d0/\n'),
                              call().flush(),
                              call().__exit__(None, None, None)])
         mock_walk.assert_called_once_with('/dst/d0')
@@ -99,12 +100,12 @@ class TestDaily(unittest.TestCase):
 
     @patch('subprocess.Popen')
     @patch('builtins.open', new_callable=mock_open)
-    def test_apache(self, mo, mock_popen):
-        """Test granting apache/www permissions.
+    def test_permission(self, mo, mock_popen):
+        """Test granting permissions.
         """
         mock_popen().wait.return_value = 0
         d = DailyDirectory('/src/d0', '/dst/d0')
-        d.apache()
+        d.permission()
         mo.assert_has_calls([call('/dst/d0.log', 'ab'),
                              call().__enter__(),
                              call().write(b'DEBUG: fix_permissions.sh /dst/d0\n'),


### PR DESCRIPTION
This PR fixes #20.

In addition, adds an `ensure_scratch()` function so that if `${CSCRATCH}` is unavailable, an alternate temporary directory can be chosen.

I'm still testing the new rsync commands and exclude files, but it looks good so far.