### PR TITLE
Update realtime nightwatch transfer

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     tests:
-        name: Standard Python tests.
+        name: Unit tests
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: true
@@ -30,15 +30,14 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip
+                python -m pip install --upgrade pip wheel
                 python -m pip install pytest
                 if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             - name: Run the test
-              run: |
-                pytest
+              run: pytest
 
     coverage:
-        name: Code coverage test.
+        name: Test coverage
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: true
@@ -57,20 +56,18 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip
+                python -m pip install --upgrade pip wheel
                 python -m pip install pytest pytest-cov coveralls
                 if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
             - name: Run the test with coverage
-              run: |
-                pytest --cov
+              run: pytest --cov
             - name: Coveralls
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                coveralls
+              run: coveralls
 
     docs:
-        name: Check Sphinx documentation.
+        name: Doc test
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
@@ -88,15 +85,12 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: |
-                python -m pip install --upgrade pip
-                python -m pip install Sphinx
+              run: python -m pip install --upgrade pip wheel Sphinx
             - name: Test the documentation
-              run: |
-                sphinx-build -W --keep-going -b html doc doc/_build/html
+              run: sphinx-build -W --keep-going -b html doc doc/_build/html
 
     style:
-        name: Check code style; allow failures.
+        name: Style check
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
@@ -114,11 +108,8 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: |
-                python -m pip install --upgrade pip
-                python -m pip install pycodestyle
-            - name: Test the style
+              run: python -m pip install --upgrade pip wheel pycodestyle
+            - name: Test the style; failures are allowed
               # This is equivalent to an allowed falure.
               continue-on-error: true
-              run: |
-                pycodestyle --count py/desitransfer
+              run: pycodestyle --count py/desitransfer

--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,17 @@
 desitransfer
 ============
 
-.. image:: https://img.shields.io/travis/desihub/desitransfer.svg
-    :target: https://travis-ci.org/desihub/desitransfer
-    :alt: Travis Build Status
+|Actions Status| |Coveralls Status| |Documentation Status|
 
-.. image:: https://coveralls.io/repos/github/desihub/desitransfer/badge.svg?branch=master
+.. |Actions Status| image:: https://github.com/desihub/desitransfer/workflows/CI/badge.svg
+    :target: https://github.com/desihub/desitransfer/actions
+    :alt: GitHub Actions CI Status
+
+.. |Coveralls Status| image:: https://coveralls.io/repos/github/desihub/desitransfer/badge.svg?branch=master
     :target: https://coveralls.io/github/desihub/desitransfer?branch=master
     :alt: Test Coverage Status
 
-.. image:: https://readthedocs.org/projects/desitransfer/badge/?version=latest
+.. |Documentation Status| image:: https://readthedocs.org/projects/desitransfer/badge/?version=latest
     :target: https://desitransfer.readthedocs.io/en/latest/
     :alt: Documentation Status
 

--- a/bin/desi_nightwatch_init.sh
+++ b/bin/desi_nightwatch_init.sh
@@ -9,7 +9,7 @@ PRGDIR=$(dirname ${PROGRAM})
 # Command line options for PRGFILE
 #
 if [[ -z "${NERSC_HOST}" ]]; then
-    PRGOPTS='--debug --no-apache'
+    PRGOPTS='--debug --no-permission'
 else
     PRGOPTS='--debug'
 fi

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -33,8 +33,8 @@ static='protodesi public/epo public/ets spectro/redux/andes spectro/redux/minisv
 #
 # Dynamic data sets may change daily.
 #
-# dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
-dynamic='spectro/redux/daily target/catalogs target/cmx_files target/secondary'
+dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
+# dynamic='spectro/redux/daily target/catalogs target/cmx_files target/secondary'
 #
 # Get options.
 #

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -67,6 +67,10 @@ if [[ -z "${DESISYNC_STATUS_URL}" ]]; then
     echo "DESISYNC_STATUS_URL must be set!" >&2
     exit 1
 fi
+if [[ -z "${CSCRATCH}" ]]; then
+    echo "CSCRATCH must be set!" >&2
+    exit 1
+fi
 src=rsync://${DESISYNC_HOSTNAME}/desi
 #
 # Check if top-level destination is set.
@@ -97,7 +101,7 @@ echo $$ > ${p}
 #
 # Wait for daily KPNO -> NERSC transfer to finish.
 #
-until /usr/bin/wget -q -O ${HOME}/scratch/daily.txt ${DESISYNC_STATUS_URL}; do
+until /usr/bin/wget -q -O ${CSCRATCH}/daily.txt ${DESISYNC_STATUS_URL}; do
     ${verbose} && echo "Daily transfer incomplete, sleeping." >&2
     /bin/sleep 15m
 done

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -33,7 +33,8 @@ static='protodesi public/epo public/ets spectro/redux/andes spectro/redux/minisv
 #
 # Dynamic data sets may change daily.
 #
-dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
+# dynamic='cmx datachallenge engineering spectro/data spectro/nightwatch/kpno spectro/redux/daily spectro/staging/lost+found sv target/catalogs target/cmx_files target/secondary'
+dynamic='spectro/redux/daily target/catalogs target/cmx_files target/secondary'
 #
 # Get options.
 #

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -243,7 +243,7 @@ The DESI Collaboration Account
         #
         if now >= self.conf['common'].getint('backup'):
             s = self.backup(d, yst)
-            if s:
+            if s and self.tape:
                 log.debug("status.update('%s', 'all', 'backup')", yst)
                 status.update(yst, 'all', 'backup')
 

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -7,6 +7,7 @@ desitransfer.daily
 Entry point for :command:`desi_daily_transfer`.
 """
 import os
+import stat
 import subprocess as sub
 import sys
 import time
@@ -74,9 +75,12 @@ class DailyDirectory(object):
         """Make a directory read-only.
         """
         for dirpath, dirnames, filenames in os.walk(self.destination):
-            os.chmod(dirpath, dir_perm)
+            if stat.S_IMODE(os.stat(dirpath).st_mode) != dir_perm:
+                os.chmod(dirpath, dir_perm)
             for f in filenames:
-                os.chmod(os.path.join(dirpath, f), file_perm)
+                fpath = os.path.join(dirpath, f)
+                if stat.S_IMODE(os.stat(fpath).st_mode) != file_perm:
+                    os.chmod(fpath, file_perm)
 
     def permission(self):
         """Set permissions for DESI collaboration access.

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -110,9 +110,9 @@ def _config():
                                             'spectro'))
     return [DailyDirectory('/exposures/desi/sps',
                            os.path.join(engineering, 'spectrograph', 'sps')),
-            DailyDirectory('/exposures/nightwatch',
-                           os.path.join(spectro, 'nightwatch', 'kpno'),
-                           extra=['--exclude-from', nightwatch_exclude]),
+            # DailyDirectory('/exposures/nightwatch',
+            #                os.path.join(spectro, 'nightwatch', 'kpno'),
+            #                extra=['--exclude-from', nightwatch_exclude]),
             DailyDirectory('/data/dts/exposures/lost+found',
                            os.path.join(spectro, 'staging', 'lost+found'),
                            dirlinks=True),

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -149,10 +149,13 @@ def _options(*args):
     prsr = ArgumentParser(description=desc)
     # prsr.add_argument('-b', '--backup', metavar='H', type=int, default=20,
     #                   help='UTC time in hours to trigger HPSS backups (default %(default)s:00 UTC).')
+    prsr.add_argument('-c', '--completion', metavar='FILE',
+                      default=os.path.join(os.environ['DESI_ROOT'], 'spectro', 'staging', 'status', 'daily.txt'),
+                      help='Signal completion of transfer via FILE (default %(default)s).')
     prsr.add_argument('-d', '--debug', action='store_true',
                       help='Set log level to DEBUG.')
-    prsr.add_argument('-D', '--daemon', action='store_true',
-                      help='Run in daemon mode.  If not specificed, the script will run once and exit.')
+    # prsr.add_argument('-D', '--daemon', action='store_true',
+    #                   help='Run in daemon mode.  If not specificed, the script will run once and exit.')
     # prsr.add_argument('-e', '--rsh', metavar='COMMAND', dest='ssh', default='/bin/ssh',
     #                   help="Use COMMAND for remote shell access (default '%(default)s').")
     prsr.add_argument('-k', '--kill', metavar='FILE',
@@ -162,8 +165,8 @@ def _options(*args):
     #                   help="Trigger DESI pipeline on this NERSC system (default %(default)s).")
     prsr.add_argument('-P', '--no-permission', action='store_false', dest='permission',
                       help='Do not set permissions for DESI collaboration access.')
-    prsr.add_argument('-s', '--sleep', metavar='H', type=int, default=24,
-                      help='In daemon mode, sleep H hours before checking for new data (default %(default)s hours).')
+    # prsr.add_argument('-s', '--sleep', metavar='H', type=int, default=24,
+    #                   help='In daemon mode, sleep H hours before checking for new data (default %(default)s hours).')
     # prsr.add_argument('-S', '--shadow', action='store_true',
     #                   help='Observe the actions of another data transfer script but do not make any changes.')
     prsr.add_argument('-V', '--version', action='version',
@@ -180,6 +183,12 @@ def main():
         An integer suitable for passing to :func:`sys.exit`.
     """
     options = _options()
+    if options.debug:
+        print("DEBUG: os.remove('%s')" % options.completion)
+    try:
+        os.remove(options.completion)
+    except FileNotFoundError:
+        pass
     while True:
         if os.path.exists(options.kill):
             print("INFO: %s detected, shutting down daily transfer script." % options.kill)
@@ -189,7 +198,12 @@ def main():
             if status != 0:
                 print("ERROR: rsync problem detected for {0.source} -> {0.destination}!".format(d))
                 return status
-        if options.daemon:
-            time.sleep(options.sleep*60*60)
-        else:
-            return 0
+        # if options.daemon:
+        #     time.sleep(options.sleep*60*60)
+        # else:
+        #     return 0
+        if options.debug:
+            print("DEBUG: daily transfer complete at %s. Writing %s." % (stamp(), options.completion))
+        with open(options.completion, 'w') as c:
+            c.write(stamp())
+        return 0

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -205,5 +205,5 @@ def main():
         if options.debug:
             print("DEBUG: daily transfer complete at %s. Writing %s." % (stamp(), options.completion))
         with open(options.completion, 'w') as c:
-            c.write(stamp())
+            c.write(stamp() + "\n")
         return 0

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -114,9 +114,9 @@ def _config():
                                             'spectro'))
     return [DailyDirectory('/exposures/desi/sps',
                            os.path.join(engineering, 'spectrograph', 'sps')),
-            # DailyDirectory('/exposures/nightwatch',
-            #                os.path.join(spectro, 'nightwatch', 'kpno'),
-            #                extra=['--exclude-from', nightwatch_exclude]),
+            DailyDirectory('/exposures/nightwatch',
+                           os.path.join(spectro, 'nightwatch', 'kpno'),
+                           extra=['--exclude-from', nightwatch_exclude]),
             DailyDirectory('/data/dts/exposures/lost+found',
                            os.path.join(spectro, 'staging', 'lost+found'),
                            dirlinks=True),
@@ -149,9 +149,9 @@ def _options(*args):
     prsr = ArgumentParser(description=desc)
     # prsr.add_argument('-b', '--backup', metavar='H', type=int, default=20,
     #                   help='UTC time in hours to trigger HPSS backups (default %(default)s:00 UTC).')
-    # prsr.add_argument('-d', '--debug', action='store_true',
-    #                   help='Set log level to DEBUG.')
-    prsr.add_argument('-d', '--daemon', action='store_true',
+    prsr.add_argument('-d', '--debug', action='store_true',
+                      help='Set log level to DEBUG.')
+    prsr.add_argument('-D', '--daemon', action='store_true',
                       help='Run in daemon mode.  If not specificed, the script will run once and exit.')
     # prsr.add_argument('-e', '--rsh', metavar='COMMAND', dest='ssh', default='/bin/ssh',
     #                   help="Use COMMAND for remote shell access (default '%(default)s').")

--- a/py/desitransfer/nightwatch.py
+++ b/py/desitransfer/nightwatch.py
@@ -53,8 +53,6 @@ def _options():
     """
     desc = "Transfer DESI nightwatch data files."
     prsr = ArgumentParser(description=desc)
-    prsr.add_argument('-A', '--no-apache', action='store_false', dest='apache',
-                      help='Do not set ACL for Apache httpd access.')
     # prsr.add_argument('-B', '--no-backup', action='store_false', dest='backup',
     #                   help="Skip NERSC HPSS backups.")
     # prsr.add_argument('-c', '--configuration', metavar='FILE',
@@ -64,11 +62,11 @@ def _options():
     prsr.add_argument('-k', '--kill', metavar='FILE',
                       default=os.path.join(os.environ['HOME'], 'stop_desi_transfer'),
                       help="Exit the script when FILE is detected (default %(default)s).")
-    # prsr.add_argument('-P', '--no-pipeline', action='store_false', dest='pipeline',
-    #                   help="Only transfer files, don't start the DESI pipeline.")
+    prsr.add_argument('-P', '--no-permission', action='store_false', dest='permission',
+                      help='Do not set permissions for DESI collaboration access.')
     # prsr.add_argument('-S', '--shadow', action='store_true',
     #                   help='Observe the actions of another data transfer script but do not make any changes.')
-    prsr.add_argument('-s', '--sleep', metavar='M', type=int, default=10,
+    prsr.add_argument('-s', '--sleep', metavar='M', type=int, default=1,
                       help='Sleep M minutes before checking for new data (default %(default)s minutes).')
     prsr.add_argument('-V', '--version', action='version',
                       version='%(prog)s {0}'.format(dtVersion))
@@ -203,7 +201,7 @@ def main():
         #
         # Correct the permissions.
         #
-        if options.apache:
+        if options.permission:
             if os.path.exists(nightdir):
                 log.info('Fixing permissions for DESI.')
                 cmd = ['fix_permissions.sh', nightdir]

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -37,8 +37,8 @@ class TestDaily(unittest.TestCase):
             self.assertEqual(c[0].source, '/exposures/desi/sps')
             self.assertEqual(c[0].destination, os.path.join(os.environ['DESI_ROOT'],
                                                             'engineering', 'spectrograph', 'sps'))
-            # self.assertEqual(c[1].extra[0], '--exclude-from')
-            self.assertTrue(c[1].dirlinks)
+            self.assertEqual(c[1].extra[0], '--exclude-from')
+            self.assertTrue(c[2].dirlinks)
 
     def test_options(self):
         """Test command-line arguments.

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -37,8 +37,8 @@ class TestDaily(unittest.TestCase):
             self.assertEqual(c[0].source, '/exposures/desi/sps')
             self.assertEqual(c[0].destination, os.path.join(os.environ['DESI_ROOT'],
                                                             'engineering', 'spectrograph', 'sps'))
-            self.assertEqual(c[1].extra[0], '--exclude-from')
-            self.assertTrue(c[2].dirlinks)
+            # self.assertEqual(c[1].extra[0], '--exclude-from')
+            self.assertTrue(c[1].dirlinks)
 
     def test_options(self):
         """Test command-line arguments.

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -103,6 +103,7 @@ class TestDaily(unittest.TestCase):
         mock_chmod.assert_has_calls([call('/dst/d0', 1512),
                                      call('/dst/d0/f1', 288),
                                      call('/dst/d0/f2', 288)])
+
     @patch('os.walk')
     @patch('os.chmod')
     def test_lock(self, mock_chmod, mock_walk):

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -43,16 +43,19 @@ class TestDaily(unittest.TestCase):
     def test_options(self):
         """Test command-line arguments.
         """
-        with patch.object(sys, 'argv',
-                          ['desi_daily_transfer', '--daemon', '--kill',
-                           os.path.expanduser('~/stop_daily_transfer')]):
-            options = _options()
-            self.assertTrue(options.permission)
-            self.assertEqual(options.sleep, 24)
-            self.assertTrue(options.daemon)
-            self.assertEqual(options.kill,
-                             os.path.join(os.environ['HOME'],
-                                          'stop_daily_transfer'))
+        with patch.dict('os.environ',
+                        {'DESI_ROOT': '/desi/root'}):
+            with patch.object(sys, 'argv',
+                              ['desi_daily_transfer', '--debug', '--kill',
+                               os.path.expanduser('~/stop_daily_transfer')]):
+                options = _options()
+                self.assertTrue(options.permission)
+                self.assertEqual(options.completion,
+                                 '/desi/root/spectro/staging/status/daily.txt')
+                self.assertTrue(options.debug)
+                self.assertEqual(options.kill,
+                                 os.path.join(os.environ['HOME'],
+                                              'stop_daily_transfer'))
 
     @patch('os.walk')
     @patch('os.stat')

--- a/py/desitransfer/test/test_daily.py
+++ b/py/desitransfer/test/test_daily.py
@@ -5,7 +5,7 @@
 import os
 import sys
 import unittest
-from unittest.mock import patch, call, mock_open
+from unittest.mock import patch, call, mock_open, Mock
 from ..daily import _config, _options, DailyDirectory
 from .. import __version__ as dtVersion
 
@@ -55,14 +55,18 @@ class TestDaily(unittest.TestCase):
                                           'stop_daily_transfer'))
 
     @patch('os.walk')
+    @patch('os.stat')
     @patch('os.chmod')
     @patch('subprocess.Popen')
     @patch('desitransfer.daily.stamp')
     @patch('builtins.open', new_callable=mock_open)
-    def test_transfer(self, mo, mock_stamp, mock_popen, mock_chmod, mock_walk):
+    def test_transfer(self, mo, mock_stamp, mock_popen, mock_chmod, mock_stat, mock_walk):
         """Test the transfer functions in DailyDirectory.transfer().
         """
         mock_walk.return_value = [('/dst/d0', [], ['f1', 'f2'])]
+        mode = Mock()
+        mode.st_mode = 137
+        mock_stat.return_value = mode
         mock_stamp.return_value = '2019-07-03'
         mock_popen().wait.return_value = 0
         d = DailyDirectory('/src/d0', '/dst/d0')
@@ -80,14 +84,18 @@ class TestDaily(unittest.TestCase):
                                      call('/dst/d0/f2', 288)])
 
     @patch('os.walk')
+    @patch('os.stat')
     @patch('os.chmod')
     @patch('subprocess.Popen')
     @patch('desitransfer.daily.stamp')
     @patch('builtins.open', new_callable=mock_open)
-    def test_transfer_extra(self, mo, mock_stamp, mock_popen, mock_chmod, mock_walk):
+    def test_transfer_extra(self, mo, mock_stamp, mock_popen, mock_chmod, mock_stat, mock_walk):
         """Test the transfer functions in DailyDirectory.transfer() with extra options.
         """
         mock_walk.return_value = [('/dst/d0', [], ['f1', 'f2'])]
+        mode = Mock()
+        mode.st_mode = 137
+        mock_stat.return_value = mode
         mock_stamp.return_value = '2019-07-03'
         mock_popen().wait.return_value = 0
         d = DailyDirectory('/src/d0', '/dst/d0', extra=['--exclude-from', 'foo'])
@@ -105,13 +113,17 @@ class TestDaily(unittest.TestCase):
                                      call('/dst/d0/f2', 288)])
 
     @patch('os.walk')
+    @patch('os.stat')
     @patch('os.chmod')
-    def test_lock(self, mock_chmod, mock_walk):
+    def test_lock(self, mock_chmod, mock_stat, mock_walk):
         """Test the lock functions in DailyDirectory.lock().
         """
         mock_walk.return_value = [('/dst/d0', ['d1', 'd2'], ['f1', 'f2']),
                                   ('/dst/d0/d1', [], ['f3']),
                                   ('/dst/d0/d2', [], ['f4'])]
+        mode = Mock()
+        mode.st_mode = 137
+        mock_stat.return_value = mode
         d = DailyDirectory('/src/d0', '/dst/d0')
         d.lock()
         mock_walk.assert_called_once_with('/dst/d0')


### PR DESCRIPTION
This PR includes several updates that were needed during the December 2020 NERSC shutdown.

* Realtime nightwatch transfers are still needed when NERSC is shut down.
* Only chmod files that need changing when locking engineering data.
* Only mark backups as successful if tape backups are actually requested.