### PR TITLE
[WIP] More visible warnings of transfer and checksum errors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: coveralls debug
+              run: coveralls
 
     docs:
         name: Doc test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,8 +63,9 @@ jobs:
               run: pytest --cov
             - name: Coveralls
               env:
+                COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: coveralls
+              run: coveralls debug
 
     docs:
         name: Doc test

--- a/bin/desi_checksum_audit.sh
+++ b/bin/desi_checksum_audit.sh
@@ -10,13 +10,13 @@ for c in $(/usr/bin/find ${data} -name \*.sha256sum); do
     echo "DEBUG: cd ${d}"
     cd ${d}
     n=$(/usr/bin/wc -l ${b} | /usr/bin/cut -d' ' -f1)
-    l=$(/usr/bin/find . -type f | /usr/bin/wc -l)
-    if ((n == l - 1)); then
+    l=$(/usr/bin/find . -type f -not -name \*.sha256sum | /usr/bin/wc -l)
+    if (( n == l )); then
         echo "DEBUG: correct number of files listed in ${c}."
-    elif ((n > l - 1)); then
-        echo "ERROR: missing files listed in ${c}!"
+    elif (( n > l )); then
+        echo "ERROR: missing files listed in ${c} (${n} listed, ${l} exist)!"
     else
-        echo "ERROR: extra files listed in ${c}!"
+        echo "ERROR: extra files not listed in ${c} (${n} listed, ${l} exist)!"
     fi
     echo "DEBUG: /usr/bin/sha256sum --check --status ${b}"
     /usr/bin/sha256sum --check --status ${b}

--- a/bin/desi_checksum_audit.sh
+++ b/bin/desi_checksum_audit.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Check Raw data checksum files.
+#
+[[ -z "${DESI_SPECTRO_DATA}" ]] && echo "DESI_SPECTRO_DATA must be set!" && exit 1
+data=${DESI_SPECTRO_DATA}
+for c in $(/usr/bin/find ${data} -name \*.sha256sum); do
+    d=$(/usr/bin/dirname ${c})
+    b=$(/usr/bin/basename ${c})
+    echo cd ${d}
+    cd ${d}
+    n=$(/usr/bin/wc -l ${b} | /usr/bin/cut -d' ' -f1)
+    l=$(/usr/bin/ls -1 | /usr/bin/wc -l)
+    if ((n == l - 1)); then
+        echo "DEBUG: correct number of files listed in ${c}."
+    elif ((n > l - 1)); then
+        echo "ERROR: missing files listed in ${c}!"
+    else
+        echo "ERROR: extra files listed in ${c}!"
+    fi
+    echo /usr/bin/sha256sum -c ${b}
+    /usr/bin/sha256sum -c ${b}
+done

--- a/bin/desi_checksum_audit.sh
+++ b/bin/desi_checksum_audit.sh
@@ -7,10 +7,10 @@ data=${DESI_SPECTRO_DATA}
 for c in $(/usr/bin/find ${data} -name \*.sha256sum); do
     d=$(/usr/bin/dirname ${c})
     b=$(/usr/bin/basename ${c})
-    echo cd ${d}
+    echo "DEBUG: cd ${d}"
     cd ${d}
     n=$(/usr/bin/wc -l ${b} | /usr/bin/cut -d' ' -f1)
-    l=$(/usr/bin/ls -1 | /usr/bin/wc -l)
+    l=$(/usr/bin/find . -type f | /usr/bin/wc -l)
     if ((n == l - 1)); then
         echo "DEBUG: correct number of files listed in ${c}."
     elif ((n > l - 1)); then
@@ -18,6 +18,10 @@ for c in $(/usr/bin/find ${data} -name \*.sha256sum); do
     else
         echo "ERROR: extra files listed in ${c}!"
     fi
-    echo /usr/bin/sha256sum -c ${b}
-    /usr/bin/sha256sum -c ${b}
+    echo "DEBUG: /usr/bin/sha256sum --check --status ${b}"
+    /usr/bin/sha256sum --check --status ${b}
+    if [[ $? != 0 ]]; then
+        echo "ERROR: checksum error(s) reported for ${b}!"
+        /usr/bin/sha256sum --check ${b}
+    fi
 done

--- a/bin/desi_transfer_init.sh
+++ b/bin/desi_transfer_init.sh
@@ -9,9 +9,9 @@ PRGDIR=$(dirname ${PROGRAM})
 # Command line options for PRGFILE
 #
 if [[ -z "${NERSC_HOST}" ]]; then
-    PRGOPTS='--no-pipeline --no-backup'
+    PRGOPTS='--no-backup'
 else
-    PRGOPTS='--no-pipeline'
+    PRGOPTS=''
 fi
 #
 # Common initialization code.

--- a/bin/desi_tucson_transfer.sh
+++ b/bin/desi_tucson_transfer.sh
@@ -122,7 +122,7 @@ for d in ${dynamic}; do
     #
     case ${d} in
         # spectro/nightwatch) inc="--include kpno/*** --exclude *" ;;
-        # spectro/redux) inc="--include oak1/*** --include daily/*** --exclude *" ;;
+        spectro/redux/daily) inc="--exclude *.tmp" ;;
         *) inc='' ;;
     esac
     #

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,17 @@
 Change Log
 ==========
 
-0.4.1 (unreleased)
+0.5.0 (unreleased)
 ------------------
 
-* No changes yet.
+* Moderate refactor of :command:`desi_transfer_daemon` (PR `#27`_):
+
+  - Remove vestigial pipeline activation code.
+  - More visible warnings of rsync and checksum errors in raw data transfers.
+  - Move all raw data to :envvar:`DESI_SPECTRO_DATA`, even if errors detected.
+  - Redo checksum on "catch-up" data.
+
+.. _`#27`: https://github.com/desihub/desitransfer/pull/27
 
 0.4.0 (2020-12-23)
 ------------------

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -81,33 +81,25 @@ def stamp(zone='US/Pacific'):
     return n.astimezone(tz).strftime('%Y-%m-%d %H:%M:%S %Z')
 
 
-def ensure_scratch(primary, alternate):
+def ensure_scratch(directories):
     """Try an alternate temporary directory if the primary temporary directory
     is unavilable.
 
     Parameters
     ----------
-    primary : :class:`str`
-        Primary temporary directory.
-    alternate : :class:`list`
-        A list of alternate directories.
+    directories : :class:`list`
+        A list of candidate directories.
 
     Returns
     -------
     The first available temporary directory found.
     """
-    if not isinstance(alternate, list):
-        alternate = [alternate]
-    try:
-        l = os.listdir(primary)
-    except FileNotFoundError:
-        for a in alternate:
-            try:
-                l = os.listdir(a)
-            except FileNotFoundError:
-                continue
-            return a
-    return primary
+    for d in directories:
+        try:
+            l = os.listdir(d)
+        except FileNotFoundError:
+            continue
+        return d
 
 
 def yesterday():

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -36,6 +36,28 @@ def empty_rsync(out):
     return all([rr.match(l) is not None for l in out.split('\n') if l])
 
 
+def new_exposures(out):
+    """Scan rsync output for exposures to be transferred.
+
+    Parameters
+    ----------
+    out : :class:`str`
+        Output from :command:`rsync`.
+
+    Returns
+    -------
+    :class:`set`
+        The unique exposure numbers detected in `out`.
+    """
+    e = set()
+    e_re = re.compile(r'([0-9]{8})/?')
+    for l in out.split('\n'):
+        m = e_re.match(l)
+        if m is not None:
+            e.add(m.groups()[0])
+    return e
+
+
 def rsync(s, d, test=False, config='dts'):
     """Set up rsync command.
 
@@ -92,7 +114,8 @@ def ensure_scratch(directories):
 
     Returns
     -------
-    The first available temporary directory found.
+    :class:`str`
+        The first available temporary directory found.
     """
     for d in directories:
         try:

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -51,9 +51,7 @@ def _options():
     prsr.add_argument('-k', '--kill', metavar='FILE',
                       default=os.path.join(os.environ['HOME'], 'stop_desi_transfer'),
                       help="Exit the script when FILE is detected (default %(default)s).")
-    prsr.add_argument('-P', '--no-pipeline', action='store_false', dest='pipeline',
-                      help="Only transfer files, don't start the DESI pipeline.")
-    prsr.add_argument('-S', '--shadow', action='store_true',
+    prsr.add_argument('-t', '--test', action='store_true',
                       help='Observe the actions of another data transfer script but do not make any changes.')
     prsr.add_argument('-V', '--version', action='version',
                       version='%(prog)s {0}'.format(dtVersion))
@@ -69,7 +67,7 @@ class TransferDaemon(object):
         The parsed command-line options.
     """
     _link_re = re.compile(r'[0-9]{8}/[0-9]{8}$')
-    _directory = namedtuple('_directory', 'source, staging, destination, hpss, expected, checksum')
+    _directory = namedtuple('_directory', 'source, staging, destination, hpss, checksum')
     _default_configuration = resource_filename('desitransfer', 'data/desi_transfer_daemon.ini')
 
     def __init__(self, options):
@@ -77,9 +75,8 @@ class TransferDaemon(object):
             self._ini = self._default_configuration
         else:
             self._ini = options.configuration
-        self.test = options.shadow
+        self.test = options.test
         self.tape = options.backup
-        self.run = options.pipeline
         getlist = lambda x: x.split(',')
         getdict = lambda x: dict([tuple(i.split(':')) for i in x.split(',')])
         self.conf = ConfigParser(defaults=os.environ,
@@ -88,15 +85,14 @@ class TransferDaemon(object):
         files = self.conf.read(self._ini)
         # assert files[0] == self._ini
         self.sections = [s for s in self.conf.sections()
-                         if s not in ('common', 'logging', 'pipeline')]
+                         if s not in ('common', 'logging')]
         self.directories = [self._directory(self.conf[s]['source'],
                                             self.conf[s]['staging'],
                                             self.conf[s]['destination'],
                                             self.conf[s]['hpss'],
-                                            self.conf[s].getlist('expected_files'),
                                             self.conf[s]['checksum_file'])
                             for s in self.sections]
-        self.scratch = ensure_scratch(self.conf['common']['scratch'], self.conf['common']['alternate_scratch'].split(','))
+        self.scratch = ensure_scratch(self.conf['common'].getlist('scratch'))
         self._configure_log(options.debug)
         return
 
@@ -137,46 +133,6 @@ The DESI Collaboration Account
         handler2.setLevel(logging.CRITICAL)
         log.parent.addHandler(handler2)
 
-    def pipeline(self, night, exposure, command=None):
-        """Generate a ``desi_night`` command to pass to the pipeline.
-
-        Parameters
-        ----------
-        night : :class:`str`
-            Night of observation.
-        exposure : :class:`str`
-            Exposure number.
-        command : :class:`str`, optional
-            Specific command to pass to ``desi_night``.
-
-        Returns
-        -------
-        :class:`list`
-            A command suitable for passing to :class:`subprocess.Popen`.
-        """
-        rename = self.conf['pipeline'].getdict('commands')
-        if command is None:
-            cmd = self.conf['pipeline']['exposure']
-        else:
-            if command in rename:
-                cmd = rename[command]
-            else:
-                cmd = command
-        c = [self.conf['pipeline']['ssh'],
-             '-q',
-             self.conf['pipeline']['host'],
-             self.conf['pipeline']['desi_night'],
-             cmd,
-             '--night', night,
-             '--expid', exposure,
-             '--nersc', self.conf['pipeline']['host'],
-             '--nersc_queue', self.conf['pipeline']['queue'],
-             '--nersc_maxnodes', self.conf['pipeline']['nodes']]
-        if command is not None:
-            c = c[:7] + c[9:]
-        log.debug(' '.join(c))
-        return c
-
     def transfer(self):
         """Loop over and transfer all configured directories.
         """
@@ -198,7 +154,7 @@ The DESI Collaboration Account
         :class:`bool`
             ``True`` if checksums are being computed.
         """
-        cmd = [self.conf['pipeline']['ssh'], '-q', 'dts',
+        cmd = [self.conf['common']['ssh'], '-q', 'dts',
                '/bin/ls', self.conf['common']['checksum_lock']]
         _, out, err = _popen(cmd)
         if out:
@@ -219,7 +175,7 @@ The DESI Collaboration Account
         #
         # Find symlinks at KPNO.
         #
-        cmd = [self.conf['pipeline']['ssh'], '-q', 'dts',
+        cmd = [self.conf['common']['ssh'], '-q', 'dts',
                '/bin/find', d.source, '-type', 'l']
         _, out, err = _popen(cmd)
         links = sorted([x for x in out.split('\n') if x])
@@ -250,6 +206,9 @@ The DESI Collaboration Account
     def exposure(self, d, link, status):
         """Data transfer operations for a single exposure.
 
+        This method will unconditionally install an exposure directory
+        in the destination, regardless of any transfer or checksum errors.
+
         Parameters
         ----------
         d : :class:`desitransfer.common.DTSDir`
@@ -273,101 +232,34 @@ The DESI Collaboration Account
             if not self.test:
                 os.makedirs(staging_night, exist_ok=True)
         #
+        # Set up DESI_SPECTRO_DATA.
+        #
+        if not os.path.isdir(destination_night):
+            log.debug("os.makedirs('%s', exist_ok=True)", destination_night)
+            log.debug("os.chmod('%s', 0o%o)", destination_night, dir_perm)
+            if not self.test:
+                os.makedirs(destination_night, exist_ok=True)
+                os.chmod(destination_night, dir_perm)
+        #
         # Has exposure already been transferred?
         #
         if not os.path.isdir(staging_exposure) and not os.path.isdir(destination_exposure):
             cmd = rsync(os.path.join(d.source, night, exposure), staging_exposure)
+            log.debug(' '.join(cmd))
             if self.test:
-                log.debug(' '.join(cmd))
                 rsync_status = '0'
             else:
                 rsync_status, out, err = _popen(cmd)
         else:
             log.debug('%s already transferred.', staging_exposure)
-            rsync_status = 'done'
+            return
         #
         # Transfer complete.
         #
         if rsync_status == '0':
             log.debug("status.update('%s', '%s', 'rsync')", night, exposure)
-            status.update(night, exposure, 'rsync')
-            #
-            # Check permissions.
-            #
-            lock_directory(staging_exposure, self.test)
-            #
-            # Verify checksums.
-            #
-            checksum_file = os.path.join(staging_exposure,
-                                         d.checksum.format(night=night, exposure=exposure))
-            if os.path.exists(checksum_file):
-                checksum_status = verify_checksum(checksum_file)
-            elif not os.path.exists(staging_exposure):
-                #
-                # This can happen in shadow mode.
-                #
-                log.debug("%s does not exist, ignore checksum error.", staging_exposure)
-                checksum_status = 1
-            else:
-                log.warning("No checksum file for %s/%s!", night, exposure)
-                checksum_status = 0
-            #
-            # Did we pass checksums?
-            #
-            if checksum_status == 0:
-                log.debug("status.update('%s', '%s', 'checksum')", night, exposure)
-                status.update(night, exposure, 'checksum')
-                #
-                # Set up DESI_SPECTRO_DATA.
-                #
-                if not os.path.isdir(destination_night):
-                    log.debug("os.makedirs('%s', exist_ok=True)", destination_night)
-                    log.debug("os.chmod('%s', 0o%o)", destination_night, dir_perm)
-                    if not self.test:
-                        os.makedirs(destination_night, exist_ok=True)
-                        os.chmod(destination_night, dir_perm)
-                #
-                # Move data into DESI_SPECTRO_DATA.
-                #
-                if not os.path.isdir(destination_exposure):
-                    log.debug("shutil.move('%s', '%s')", staging_exposure, destination_night)
-                    if not self.test:
-                        shutil.move(staging_exposure, destination_night)
-                #
-                # Is this a "realistic" exposure?
-                #
-                if (self.run and
-                    all([os.path.exists(os.path.join(destination_exposure,
-                                                     f.format(exposure=exposure)))
-                         for f in d.expected])):
-                    #
-                    # Run update
-                    #
-                    cmd = self.pipeline(night, exposure)
-                    if not self.test:
-                        _, out, err = _popen(cmd)
-                    log.debug("status.update('%s', '%s', 'pipeline')", night, exposure)
-                    status.update(night, exposure, 'pipeline')
-                    for k in ('flats', 'arcs', 'science'):
-                        if os.path.exists(os.path.join(destination_exposure,
-                                                       '{0}-{1}-{2}.done'.format(k, night, exposure))):
-                            cmd = self.pipeline(night, exposure, command=k)
-                            if not self.test:
-                                _, out, err = _popen(cmd)
-                            log.debug("status.update('%s', '%s', 'pipeline', last='%s')",
-                                      night, exposure, k)
-                            status.update(night, exposure, 'pipeline', last=k)
-                else:
-                    log.info("%s/%s appears to be test data. Skipping pipeline activation.", night, exposure)
-            else:
-                log.critical("Checksum problem detected for %s/%s, check logs!", night, exposure)
-                log.debug("status.update('%s', '%s', 'checksum', failure=True)", night, exposure)
-                status.update(night, exposure, 'checksum', failure=True)
-        elif rsync_status == 'done':
-            #
-            # Do nothing, successfully.
-            #
-            pass
+            if not self.test:
+                status.update(night, exposure, 'rsync')
         else:
             log.critical('rsync problem (status = %s) detected for %s/%s, check logs!',
                          rsync_status, night, exposure)
@@ -375,6 +267,41 @@ The DESI Collaboration Account
             log.error('rsync STDERR = %s', err)
             log.debug("status.update('%s', '%s', 'rsync', failure=True)", night, exposure)
             status.update(night, exposure, 'rsync', failure=True)
+        #
+        # Check permissions.
+        #
+        log.debug("lock_directory('%s', %s)", staging_exposure, str(self.test))
+        lock_directory(staging_exposure, self.test)
+        #
+        # Verify checksums.
+        #
+        checksum_file = os.path.join(staging_exposure,
+                                     d.checksum.format(night=night, exposure=exposure))
+        log.debug("verify_checksum('%s')", checksum_file)
+        if not self.test:
+            if os.path.exists(checksum_file):
+                checksum_status = verify_checksum(checksum_file)
+                #
+                # Did we pass checksums?
+                #
+                if checksum_status == 0:
+                    log.debug("status.update('%s', '%s', 'checksum')", night, exposure)
+                    status.update(night, exposure, 'checksum')
+                else:
+                    log.critical("Checksum problem detected for %s/%s, check logs!", night, exposure)
+                    log.debug("status.update('%s', '%s', 'checksum', failure=True)", night, exposure)
+                    status.update(night, exposure, 'checksum', failure=True)
+            else:
+                log.warning("No checksum file for %s/%s!", night, exposure)
+                log.debug("status.update('%s', '%s', 'checksum', failure=True)", night, exposure)
+                status.update(night, exposure, 'checksum', failure=True)
+        #
+        # Move data into DESI_SPECTRO_DATA.
+        #
+        if not os.path.isdir(destination_exposure):
+            log.debug("shutil.move('%s', '%s')", staging_exposure, destination_night)
+            if not self.test:
+                shutil.move(staging_exposure, destination_night)
 
     def catchup(self, d, night):
         """Do a "catch-up" transfer to catch delayed files in the morning, rather than at noon.
@@ -397,7 +324,7 @@ The DESI Collaboration Account
             sync_file = os.path.join(self.scratch,
                                      'ketchup_{0}_{1}.txt'.format(ketchup_file, night))
             if self.test:
-                sync_file = sync_file.replace('.txt', '.shadow.txt')
+                sync_file = sync_file.replace('.txt', '.test.txt')
             if os.path.exists(sync_file):
                 log.debug("%s detected, catch-up transfer is done.", sync_file)
             else:
@@ -438,7 +365,7 @@ The DESI Collaboration Account
             hpss_file = d.hpss.replace('/', '_')
             ls_file = os.path.join(self.scratch, hpss_file + '.txt')
             if self.test:
-                ls_file = ls_file.replace('.txt', '.shadow.txt')
+                ls_file = ls_file.replace('.txt', '.test.txt')
             log.debug("os.remove('%s')", ls_file)
             try:
                 os.remove(ls_file)

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -211,7 +211,7 @@ The DESI Collaboration Account
 
         Parameters
         ----------
-        d : :class:`desitransfer.common.DTSDir`
+        d : :func:`collections.namedtuple`
             Configuration for the destination directory.
         link : :class:`str`
             The exposure path.
@@ -345,14 +345,14 @@ The DESI Collaboration Account
                     #
                     # Re-check the checksums for exposures that changed.
                     #
-                    # e = new_exposures(out)
-                    # if len(e) == 0:
-                    #     log.warning('No updated exposures in night %s detected.', night)
-                    # else:
-                    #     for exposure in e:
-                    #         checksum_file = os.path.join(os.path.join(d.destination, night, exposure),
-                    #                                      d.checksum.format(night=night, exposure=exposure))
-                    #         log.debug("verify_checksum('%s')", checksum_file)
+                    e = new_exposures(out)
+                    if len(e) == 0:
+                        log.warning('No updated exposures in night %s detected.', night)
+                    else:
+                        for exposure in e:
+                            checksum_file = os.path.join(os.path.join(d.destination, night, exposure),
+                                                         d.checksum.format(night=night, exposure=exposure))
+                            log.debug("verify_checksum('%s')", checksum_file)
                     #         if not self.test:
                     #             if os.path.exists(checksum_file):
                     #                 checksum_status = verify_checksum(checksum_file)

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -287,7 +287,10 @@ The DESI Collaboration Account
                 shutil.move(staging_exposure, destination_night)
 
     def checksum(self, checksum_file, status):
-        """Verify checksum associated with `exposure` and report status.
+        """Verify checksum associated with `checksum_file` and report status.
+
+        The status is reported via log messages and messages passed
+        to the `status` object, not via a return value.
 
         Parameters
         ----------

--- a/py/desitransfer/daemon.py
+++ b/py/desitransfer/daemon.py
@@ -193,12 +193,12 @@ The DESI Collaboration Account
         yst = yesterday()
         now = int(dt.datetime.utcnow().strftime('%H'))
         if now >= self.conf['common'].getint('catchup'):
-            self.catchup(d, yst)
+            self.catchup(d, yst, status)
         #
         # Are any nights eligible for backup?
         #
         if now >= self.conf['common'].getint('backup'):
-            s = self.backup(d, yst)
+            s = self.backup(d, yst, status)
             if s and self.tape:
                 log.debug("status.update('%s', 'all', 'backup')", yst)
                 status.update(yst, 'all', 'backup')

--- a/py/desitransfer/data/desi_transfer_daemon.ini
+++ b/py/desitransfer/data/desi_transfer_daemon.ini
@@ -10,9 +10,6 @@ staging = ${DESI_ROOT}/spectro/staging/raw
 destination = ${DESI_SPECTRO_DATA}
 # Directory where HPSS backups will be stored.
 hpss = desi/spectro/data
-# A valid exposure--that the pipeline should be run on--should contain these files.
-# expected_files = desi-{exposure}.fits.fz,fibermap-{exposure}.fits,guider-{exposure}.fits.fz
-expected_files = desi-{exposure}.fits.fz
 # Checksum files have this format.
 checksum_file = checksum-{exposure}.sha256sum
 
@@ -20,9 +17,9 @@ checksum_file = checksum-{exposure}.sha256sum
 # Common configuration for all transfers.
 #
 [common]
-# Use this directory for temporary files.
-scratch = ${CSCRATCH}
-alternate_scratch = ${HOME}/tmp,${HOME}/scratch
+# Use this directory for temporary files.  The first available directory
+# in this list will be used.
+scratch = ${CSCRATCH},${HOME}/tmp,${HOME}/scratch
 # The presence of this file indicates checksums are being computed.
 checksum_lock = /tmp/checksum-running
 # UTC time in hours to look for delayed files.
@@ -34,6 +31,8 @@ backup = 20
 # Sleep this many minutes before checking for new data.
 # sleep = 10
 sleep = 1
+# Path to ssh.
+ssh = /bin/ssh
 
 #
 # Log file configuration.
@@ -46,22 +45,3 @@ size = 100000000
 backups = 100
 # Send critical alerts to these email addresses.
 to = desi-alarms-transfer@desi.lbl.gov
-
-#
-# Configuration for generating pipeline commands.
-#
-[pipeline]
-# This is the effective pipeline command on the remote host.
-desi_night = ${HOME}/bin/wrap_desi_night.sh
-# Path to ssh.
-ssh = /bin/ssh
-# Run pipeline commands on this remote host.
-host = cori
-# NERSC queue.
-queue = realtime
-# Nodes for the job.
-nodes = 25
-# Map 'done' files to these pipeline commands.
-commands = science:redshifts
-# Use this pipeline command for exposures that are not special (i.e. not 'last').
-exposure = update

--- a/py/desitransfer/data/desi_transfer_status.js
+++ b/py/desitransfer/data/desi_transfer_status.js
@@ -39,15 +39,13 @@ $(function() {
             var r = "btn-success";
             for (var k = 0; k < this.exposures.length; k++) {
                 for (var l = 0; l < s.length; l++) {
-                    if (Exposure.display[l]) {
-                        if (!this.exposures[k].stage[s[l]].success) {
-                            //
-                            // It's not successful, but is it complete?
-                            //
-                            if (this.exposures[k].stage[s[l]].stamp > 0)
-                                return "btn-danger";
-                            r = "btn-warning";
-                        }
+                    if (!this.exposures[k].stage[s[l]].success) {
+                        //
+                        // It's not successful, but is it complete?
+                        //
+                        if (this.exposures[k].stage[s[l]].stamp > 0)
+                            return "btn-danger";
+                        r = "btn-warning";
                     }
                 }
             }
@@ -117,8 +115,7 @@ $(function() {
         }
         var E = Exposure, Ep = Exposure.prototype;
         E.padding = 8;
-        E.stages = ["rsync", "checksum", "pipeline", "backup"];
-        E.display = [true, true, false, true];
+        E.stages = ["rsync", "checksum", "backup"];
         //
         // Pad integers out to 8 characters.
         //
@@ -133,8 +130,7 @@ $(function() {
         Ep.header = function() {
             var h = "<thead><tr><th class=\"text-uppercase\">exposure</th>";
             for (var k = 0; k < Exposure.stages.length; k++) {
-                if (Exposure.display[k])
-                    h += "<th class=\"text-uppercase\">" + Exposure.stages[k] + "</th>";
+                h += "<th class=\"text-uppercase\">" + Exposure.stages[k] + "</th>";
             }
             h += "<th class=\"text-uppercase\">comment</th></tr></thead>";
             return h;
@@ -146,16 +142,14 @@ $(function() {
             var r = "<tr id=\"e" + this.toString() +"\">" +
                     "<td>" + this.pad() + "</td>";
             for (var k = 0; k < Exposure.stages.length; k++) {
-                if (Exposure.display[k]) {
-                    var c = "table-warning";
-                    var stamp = "INCOMPLETE";
-                    if (this.stage[Exposure.stages[k]].stamp != 0) {
-                        c = this.stage[Exposure.stages[k]].success ? "table-success" : "table-danger";
-                        var d = new Date(this.stage[Exposure.stages[k]].stamp);
-                        stamp = d.toISOString();
-                    }
-                    r +=  "<td class=\"" + c + "\">" + stamp + "</td>";
+                var c = "table-warning";
+                var stamp = "INCOMPLETE";
+                if (this.stage[Exposure.stages[k]].stamp != 0) {
+                    c = this.stage[Exposure.stages[k]].success ? "table-success" : "table-danger";
+                    var d = new Date(this.stage[Exposure.stages[k]].stamp);
+                    stamp = d.toISOString();
                 }
+                r +=  "<td class=\"" + c + "\">" + stamp + "</td>";
             }
             r += "<td>" + this.l + "</td></tr>";
             return r;

--- a/py/desitransfer/data/desi_transfer_status.js
+++ b/py/desitransfer/data/desi_transfer_status.js
@@ -111,7 +111,7 @@ $(function() {
                 this.stage[r[2]] = {"success": r[3], "stamp": r[5]};
             }
             // this.c = this.status ? "bg-success" : "bg-danger";
-            this.l = r[4].length > 0 ? " Last " + r[4] + " exposure." : "";
+            // this.l = r[4].length > 0 ? " Last " + r[4] + " exposure." : "";
         }
         var E = Exposure, Ep = Exposure.prototype;
         E.padding = 8;
@@ -132,7 +132,8 @@ $(function() {
             for (var k = 0; k < Exposure.stages.length; k++) {
                 h += "<th class=\"text-uppercase\">" + Exposure.stages[k] + "</th>";
             }
-            h += "<th class=\"text-uppercase\">comment</th></tr></thead>";
+            // h += "<th class=\"text-uppercase\">comment</th></tr></thead>";
+            h += "</tr></thead>";
             return h;
         };
         //
@@ -151,7 +152,8 @@ $(function() {
                 }
                 r +=  "<td class=\"" + c + "\">" + stamp + "</td>";
             }
-            r += "<td>" + this.l + "</td></tr>";
+            // r += "<td>" + this.l + "</td></tr>";
+            r += "</tr>";
             return r;
         };
         //

--- a/py/desitransfer/status.py
+++ b/py/desitransfer/status.py
@@ -205,7 +205,7 @@ def _options():
     prsr.add_argument('expid', metavar='EXPID',
                       help="Exposure number, or 'all'.")
     prsr.add_argument('stage',
-                      choices=['rsync', 'checksum', 'pipeline', 'backup'],
+                      choices=['rsync', 'checksum', 'backup'],
                       help="Transfer stage.")
     return prsr.parse_args()
 

--- a/py/desitransfer/test/test_common.py
+++ b/py/desitransfer/test/test_common.py
@@ -81,13 +81,13 @@ total size is 118,417,836,324  speedup is 494,367.55
         """Test ensure_scratch.
         """
         tmp = self.tmp.name
-        t = ensure_scratch(tmp, ['/foo', '/bar'])
+        t = ensure_scratch([tmp, '/foo', '/bar'])
         self.assertEqual(t, tmp)
-        t = ensure_scratch('/foo', tmp)
+        t = ensure_scratch(['/foo', tmp])
         self.assertEqual(t, tmp)
-        t = ensure_scratch('/foo', ['/bar', tmp])
+        t = ensure_scratch(['/foo', '/bar', tmp])
         self.assertEqual(t, tmp)
-        t = ensure_scratch('/foo', ['/bar', '/abcdefg', tmp])
+        t = ensure_scratch(['/foo', '/bar', '/abcdefg', tmp])
         self.assertEqual(t, tmp)
 
     @patch('desitransfer.common.dt')

--- a/py/desitransfer/test/test_common.py
+++ b/py/desitransfer/test/test_common.py
@@ -7,7 +7,7 @@ import os
 import unittest
 from unittest.mock import patch
 from tempfile import TemporaryDirectory
-from ..common import dir_perm, file_perm, empty_rsync, rsync, stamp, ensure_scratch, yesterday, today
+from ..common import dir_perm, file_perm, empty_rsync, new_exposures, rsync, stamp, ensure_scratch, yesterday, today
 
 
 class TestCommon(unittest.TestCase):
@@ -54,6 +54,24 @@ sent 765 bytes  received 238,769 bytes  159,689.33 bytes/sec
 total size is 118,417,836,324  speedup is 494,367.55
 """
         self.assertFalse(empty_rsync(r))
+
+    def test_new_exposures(self):
+        """Test parsing of rsync output for new exposures.
+        """
+        r = """receiving incremental file list
+
+sent 765 bytes  received 238,769 bytes  159,689.33 bytes/sec
+total size is 118,417,836,324  speedup is 494,367.55
+"""
+        self.assertEqual(len(new_exposures(r)), 0)
+        r = """receiving incremental file list
+12345678/foo.txt
+12345679/foo.txt
+
+sent 765 bytes  received 238,769 bytes  159,689.33 bytes/sec
+total size is 118,417,836,324  speedup is 494,367.55
+"""
+        self.assertEqual(len(new_exposures(r)), 2)
 
     def test_rsync(self):
         """Test construction of rsync command.

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -661,7 +661,8 @@ total size is 118,417,836,324  speedup is 494,367.55
         mock_rsync.assert_called_once_with('/data/dts/exposures/raw', '/desi/root/spectro/data', '20190703', False)
         mock_log.warning.assert_has_calls([call('New files detected in %s!', '20190703')])
         mock_log.debug.assert_has_calls([call("verify_checksum('%s')", '/desi/root/spectro/data/20190703/00001234/checksum-00001234.sha256sum'),
-                                         call("verify_checksum('%s')", '/desi/root/spectro/data/20190703/00001235/checksum-00001235.sha256sum')])
+                                         call("verify_checksum('%s')", '/desi/root/spectro/data/20190703/00001235/checksum-00001235.sha256sum')],
+                                         any_order=True)
 
     @patch('desitransfer.daemon.rsync_night')
     @patch('os.chdir')

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -201,8 +201,8 @@ desi_spectro_data_20190702.tar.idx
         transfer.directory(c[0])
         mock_status.assert_called_once_with(os.path.join(os.path.dirname(c[0].staging), 'status'))
         mock_popen.assert_called_once_with(['/bin/ssh', '-q', 'dts', '/bin/find', c[0].source, '-type', 'l'])
-        mock_catchup.assert_called_once_with(c[0], '20190703')
-        mock_backup.assert_called_once_with(c[0], '20190703')
+        mock_catchup.assert_called_once_with(c[0], '20190703', mock_status())
+        mock_backup.assert_called_once_with(c[0], '20190703', mock_status())
         mock_status().update.assert_called_once_with('20190703', 'all', 'backup')
         #
         # No links.

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -626,7 +626,13 @@ desi_spectro_data_20190702.tar.idx
             with patch('desitransfer.daemon.log') as l:
                 o = verify_checksum(c)
         self.assertEqual(o, -1)
-        l.error.assert_has_calls([call("%s does not match the number of files!", c)])
+        l.error.assert_has_calls([call("%s lists %d file(s) that are not present!", c, 1)])
+        with patch('os.listdir') as mock_listdir:
+            mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt', 'test_file_2.txt', 'test_file_3.txt']
+            with patch('desitransfer.daemon.log') as l:
+                o = verify_checksum(c)
+        self.assertEqual(o, 1)
+        l.error.assert_has_calls([call("%d files are not listed in %s!", 1, c)])
         #
         # Bad list of files.
         #
@@ -648,8 +654,8 @@ desi_spectro_data_20190702.tar.idx
                     h.hexdigest.return_value = 'abcdef'
                     o = verify_checksum(c)
         self.assertEqual(o, 2)
-        l.error.assert_has_calls([call("Checksum mismatch for %s!", os.path.join(d, 'test_file_1.txt')),
-                                  call("Checksum mismatch for %s!", os.path.join(d, 'test_file_2.txt'))])
+        l.error.assert_has_calls([call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_1.txt'), c),
+                                  call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_2.txt'), c)])
 
     @patch('os.walk')
     @patch('os.chmod')


### PR DESCRIPTION
This PR:

* Fixes #25
* Fixes #26

There are still some open questions from the issues listed above which I consolidate here:

- [x] How rigorously to we re-verify checksums, for example after an early-morning catch-up transfer (see #26)?
- [x] What are the exact criteria for allowing raw data to be transferred from the staging area to `$DESI_SPECTRO_REDUX` (see #25)?