### PR TITLE
Fix DESI night definition for nightwatch transfers

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 0.5.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix nightwatch transfer night offset (PR `#28`_).
+
+.. _`#28`: https://github.com/desihub/desitransfer/pull/28
+
 
 0.5.0 (2021-01-18)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,9 @@ Change Log
 0.5.1 (unreleased)
 ------------------
 
-* Fix nightwatch transfer night offset (PR `#28`_).
+* Fix nightwatch transfer night offset (PR `#31`_).
 
-.. _`#28`: https://github.com/desihub/desitransfer/pull/28
+.. _`#31`: https://github.com/desihub/desitransfer/pull/31
 
 
 0.5.0 (2021-01-18)

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -133,5 +133,8 @@ def yesterday():
 
 def today():
     """Today's date in DESI "NIGHT" format, YYYYMMDD.
+
+    This formulation, with the offset ``7/24+0.5``, is inherited from previous
+    nightwatch transfer scripts.
     """
-    return (dt.datetime.now() - dt.timedelta(7/24+0.5)).strftime('%Y%m%d')
+    return (dt.datetime.utcnow() - dt.timedelta(7/24+0.5)).strftime('%Y%m%d')

--- a/py/desitransfer/test/test_common.py
+++ b/py/desitransfer/test/test_common.py
@@ -121,7 +121,7 @@ total size is 118,417,836,324  speedup is 494,367.55
     def test_today(self, mock_dt):
         """Test today's date.
         """
-        mock_dt.datetime.now.return_value = datetime.datetime(2019, 7, 3, 5, 0, 0)
+        mock_dt.datetime.utcnow.return_value = datetime.datetime(2019, 7, 3, 5, 0, 0)
         mock_dt.timedelta.return_value = datetime.timedelta(7/24+0.5)
         y = today()
         self.assertEqual(y, '20190702')


### PR DESCRIPTION
In previous versions of the KPNO nightwatch transfer script, the DESI night was determined via 
```python
(dt.datetime.utcnow() - dt.timedelta(7/24+0.5)).strftime('%Y%m%d')
```
which got changed to
```python
(dt.datetime.now() - dt.timedelta(7/24+0.5)).strftime('%Y%m%d')
```
while incorporating the nightwatch transfer code into the package.  This PR reverts that change.