### PR TITLE
Update Tucson transfer for public data

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,13 @@
 Change Log
 ==========
 
-0.7.2 (unreleased)
+0.7.2 (2022-08-05)
 ------------------
 
-* No changes yet.
+* Adjusted Tucson transfer configuration in light of upcoming public data
+  releases (PR `#48`_).
+
+.. _`#48`: https://github.com/desihub/desitransfer/pull/48
 
 0.7.1 (2022-03-22)
 ------------------

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -40,6 +40,8 @@ static = ['cmx',
           'spectro/redux/everest',
           'spectro/templates/basis_templates',
           'sv',
+          'target/catalogs',
+          'target/secondary',
           'target/cmx_files']
 
 
@@ -51,9 +53,7 @@ dynamic = ['spectro/data',
            'spectro/redux/daily/preproc',
            'spectro/redux/daily/tiles',
            'engineering/focalplane',
-           'software/AnyConnect',
-           'target/catalogs',
-           'target/secondary']
+           'software/AnyConnect']
 
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
@@ -62,7 +62,8 @@ includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
             'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits"],
             'spectro/redux/daily/tiles': ["--exclude", "*.tmp"],
-            'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"]}
+            'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"],
+            'target/catalogs': ["--include", "dr8", "--include", "dr9", "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}
 
 
 def _configure_log(debug):

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -57,6 +57,7 @@ dynamic = ['spectro/data',
 
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
+            'spectro/data': ["--exclude", "2018*", "--exclude", "2019*", "--exclude", "2020*", "--exclude", "2021*"],
             # 'spectro/nightwatch': ["--include", "kpno/***", "--exclude", "*"],
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -61,7 +61,7 @@ includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
             'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],
-            'spectro/redux/daily/tiles': ["--exclude", "*.tmp"],
+            'spectro/redux/daily/tiles': ["--exclude", "*.tmp", "--exclude", "temp"],
             'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"],
             'target/catalogs': ["--include", "dr8", "--include", "dr9", "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}
 

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -58,9 +58,9 @@ dynamic = ['spectro/data',
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             # 'spectro/nightwatch': ["--include", "kpno/***", "--exclude", "*"],
-            'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
+            'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
-            'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits"],
+            'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],
             'spectro/redux/daily/tiles': ["--exclude", "*.tmp"],
             'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"],
             'target/catalogs': ["--include", "dr8", "--include", "dr9", "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}


### PR DESCRIPTION
This adjusts the configuration for Tucson transfers to account for data that have been moved to public release locations, especially targeting data.

I think this is fairly non-controversial and I will self-merge soon.