### PR TITLE
Automatically exclude previous years' raw data

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -90,6 +90,35 @@ jobs:
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 
+    api:
+        name: API doc completeness test
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                python-version: ['3.9']
+        env:
+            DESIUTIL_VERSION: module-script
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: |
+                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+            - name: Generate api.rst
+              run: desi_api_file --api ./api.rst desitransfer
+            - name: Compare generated api.rst to checked-in version
+              run: diff --ignore-space-change --ignore-blank-lines ./api.rst ./doc/api.rst
+
     style:
         name: Style check
         runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ MANIFEST
 # Other
 .*.swp
 *~
+.vscode
+.env
 
 # Mac OSX
 .DS_Store

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,7 +11,8 @@ Change Log
 0.9.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Exclude ``2022*`` from raw data transfers to Tucson; add API documentation
+  completeness test.
 
 0.9.0 (2022-12-16)
 ------------------

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -40,6 +40,7 @@ static = ['cmx',
           'spectro/redux/denali',
           'spectro/redux/everest',
           'spectro/templates/basis_templates',
+          'survey/ops/surveyops/trunk',
           'sv',
           'target/catalogs',
           'target/secondary',
@@ -65,6 +66,7 @@ includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],
             'spectro/redux/daily/tiles': ["--exclude", "*.tmp", "--exclude", "temp"],
             'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"],
+            'survey/ops/surveyops/trunk': ["--exclude", ".svn", "--exclude", "cronupdate.log"],
             'target/catalogs': ["--include", "dr8", "--include", "dr9", "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}
 
 

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -58,7 +58,7 @@ dynamic = ['spectro/data',
 
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
-            'spectro/data': (' '.join([f'--exclude {y:d}*' for y in range(2018, time.localtime().year)])).split(),
+            'spectro/data': (' '.join([f'--exclude {y:d}*' for y in range(2018, time.localtime().tm_year)])).split(),
             # 'spectro/nightwatch': ["--include", "kpno/***", "--exclude", "*"],
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -58,7 +58,7 @@ dynamic = ['spectro/data',
 
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
-            'spectro/data': ["--exclude", "2018*", "--exclude", "2019*", "--exclude", "2020*", "--exclude", "2021*"],
+            'spectro/data': ["--exclude", "2018*", "--exclude", "2019*", "--exclude", "2020*", "--exclude", "2021*", "--exclude", "2022*"],
             # 'spectro/nightwatch': ["--include", "kpno/***", "--exclude", "*"],
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -58,7 +58,7 @@ dynamic = ['spectro/data',
 
 
 includes = {'spectro/desi_spectro_calib': ["--exclude", ".svn"],
-            'spectro/data': ["--exclude", "2018*", "--exclude", "2019*", "--exclude", "2020*", "--exclude", "2021*", "--exclude", "2022*"],
+            'spectro/data': (' '.join([f'--exclude {y:d}*' for y in range(2018, time.localtime().year)])).split(),
             # 'spectro/nightwatch': ["--include", "kpno/***", "--exclude", "*"],
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],


### PR DESCRIPTION
This PR automates the process of skipping transfers of previous years' raw data, which has presumably been transferred already.