### PR TITLE
Potentially speed up Tucson nightwatch mirror

### DIFF
--- a/bin/desi_tucson_transfer_catchup.sh
+++ b/bin/desi_tucson_transfer_catchup.sh
@@ -32,6 +32,7 @@ for d in engineering/focalplane engineering/focalplane/hwtables \
         engineering/focalplane) priority='nice'; exclude='--exclude archive --exclude hwtables --exclude *.ipynb --exclude .ipynb_checkpoints' ;;
         engineering/focalplane/hwtables) priority='nice'; exclude='--include *.csv --exclude *' ;;
         spectro/data) priority=''; exclude='--exclude 2018* --exclude 2019* --exclude 2020* --exclude 2021* --exclude 2022* --exclude 2023*' ;;
+        spectro/nightwatch/kpno) priority='nice'; exclude='--exclude 2021* --exclude 2022* --exclude 2023*' ;;
         spectro/redux/daily) priority=''; exclude='--exclude *.tmp --exclude attic --exclude exposures --exclude preproc --exclude temp --exclude tiles' ;;
         spectro/redux/daily/exposures) priority=''; exclude='--exclude *.tmp' ;;
         spectro/redux/daily/preproc) priority=''; exclude='--exclude *.tmp --exclude preproc-*.fits --exclude preproc-*.fits.gz' ;;

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -10,6 +10,7 @@ import datetime as dt
 import os
 import re
 import stat
+import time
 import pytz
 
 MST = pytz.timezone('America/Phoenix')
@@ -174,3 +175,20 @@ def idle_time(start=8, end=12, tz=None):
         return (i - s) // dt.timedelta(seconds=1)
     e = dt.datetime(i.year, i.month, i.day, end, 0, 0, tzinfo=tz)
     return (e - i) // dt.timedelta(seconds=1)
+
+
+def exclude_years(start_year):
+    """Generate rsync ``--exclude`` statements of the form ``--exclude 2020*``.
+
+    Parameters
+    ----------
+    start_year : :class:`int`
+        First year to exclude.
+
+    Returns
+    -------
+    :class:`list`
+        A list suitable for appending to a command.
+    """
+    return (' '.join([f'--exclude {y:d}*' for y in range(start_year, time.localtime().tm_year)])).split()
+

--- a/py/desitransfer/common.py
+++ b/py/desitransfer/common.py
@@ -35,7 +35,7 @@ def empty_rsync(out):
         ``True`` if there are no files to transfer.
     """
     rr = re.compile(r'(receiving|sent [0-9]+ bytes|total size)')
-    return all([rr.match(l) is not None for l in out.split('\n') if l])
+    return all([rr.match(out_line) is not None for out_line in out.split('\n') if out_line])
 
 
 def new_exposures(out):
@@ -53,8 +53,8 @@ def new_exposures(out):
     """
     e = set()
     e_re = re.compile(r'([0-9]{8})/?')
-    for l in out.split('\n'):
-        m = e_re.match(l)
+    for out_line in out.split('\n'):
+        m = e_re.match(out_line)
         if m is not None:
             e.add(m.groups()[0])
     return e
@@ -126,7 +126,7 @@ def ensure_scratch(directories):
     """
     for d in directories:
         try:
-            l = os.listdir(d)
+            dir_list = os.listdir(d)
         except FileNotFoundError:
             continue
         return d
@@ -144,7 +144,7 @@ def today():
     This formulation, with the offset ``7/24+0.5``, is inherited from previous
     nightwatch transfer scripts.
     """
-    return (dt.datetime.utcnow() - dt.timedelta(7/24+0.5)).strftime('%Y%m%d')
+    return (dt.datetime.utcnow() - dt.timedelta(7 / 24 + 0.5)).strftime('%Y%m%d')
 
 
 def idle_time(start=8, end=12, tz=None):
@@ -191,4 +191,3 @@ def exclude_years(start_year):
         A list suitable for appending to a command.
     """
     return (' '.join([f'--exclude {y:d}*' for y in range(start_year, time.localtime().tm_year)])).split()
-

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -56,14 +56,14 @@ class DailyDirectory(object):
         if self.extra:
             for i, e in enumerate(self.extra):
                 cmd.insert(cmd.index('--omit-dir-times') + 1 + i, e)
-        with open(self.log, 'ab') as l:
-            l.write(("DEBUG: desi_daily_transfer %s\n" % dtVersion).encode('utf-8'))
-            l.write(("DEBUG: %s\n" % ' '.join(cmd)).encode('utf-8'))
-            l.write(("DEBUG: Transfer start: %s\n" % stamp()).encode('utf-8'))
-            l.flush()
-            p = sub.Popen(cmd, stdout=l, stderr=sub.STDOUT)
+        with open(self.log, 'ab') as logfile:
+            logfile.write(("DEBUG: desi_daily_transfer %s\n" % dtVersion).encode('utf-8'))
+            logfile.write(("DEBUG: %s\n" % ' '.join(cmd)).encode('utf-8'))
+            logfile.write(("DEBUG: Transfer start: %s\n" % stamp()).encode('utf-8'))
+            logfile.flush()
+            p = sub.Popen(cmd, stdout=logfile, stderr=sub.STDOUT)
             status = p.wait()
-            l.write(("DEBUG: Transfer complete: %s\n" % stamp()).encode('utf-8'))
+            logfile.write(("DEBUG: Transfer complete: %s\n" % stamp()).encode('utf-8'))
         if status == 0:
             self.lock()
             if permission:
@@ -80,8 +80,8 @@ class DailyDirectory(object):
                 fpath = os.path.join(dirpath, f)
                 if stat.S_IMODE(os.stat(fpath).st_mode) != file_perm:
                     os.chmod(fpath, file_perm)
-        with open(self.log, 'ab') as l:
-            l.write(("DEBUG: Lock complete: %s\n" % stamp()).encode('utf-8'))
+        with open(self.log, 'ab') as logfile:
+            logfile.write(("DEBUG: Lock complete: %s\n" % stamp()).encode('utf-8'))
 
     def permission(self):
         """Set permissions for DESI collaboration access.
@@ -95,12 +95,12 @@ class DailyDirectory(object):
             The status returned by :command:`fix_permissions.sh`.
         """
         cmd = ['fix_permissions.sh', self.destination]
-        with open(self.log, 'ab') as l:
-            l.write(("DEBUG: %s\n" % ' '.join(cmd)).encode('utf-8'))
-            l.flush()
-            p = sub.Popen(cmd, stdout=l, stderr=sub.STDOUT)
+        with open(self.log, 'ab') as logfile:
+            logfile.write(("DEBUG: %s\n" % ' '.join(cmd)).encode('utf-8'))
+            logfile.flush()
+            p = sub.Popen(cmd, stdout=logfile, stderr=sub.STDOUT)
             status = p.wait()
-            l.write(("DEBUG: Permission reset complete: %s\n" % stamp()).encode('utf-8'))
+            logfile.write(("DEBUG: Permission reset complete: %s\n" % stamp()).encode('utf-8'))
         return status
 
 

--- a/py/desitransfer/nightwatch.py
+++ b/py/desitransfer/nightwatch.py
@@ -11,7 +11,8 @@ A cronjob running as desi@dtn01.nersc.gov ensures that this daemon is running.
 
 Catchup on a specific night::
 
-    NIGHT=20200124 && rsync -rlvt --exclude-from ${DESITRANSFER}/py/desitransfer/data/desi_nightwatch_transfer_exclude.txt dts:/exposures/nightwatch/${NIGHT}/ /global/cfs/cdirs/desi/spectro/nightwatch/kpno/${NIGHT}/
+    NIGHT=20200124 && rsync -rlvt --exclude-from ${DESITRANSFER}/py/desitransfer/data/desi_nightwatch_transfer_exclude.txt \
+        dts:/exposures/nightwatch/${NIGHT}/ /global/cfs/cdirs/desi/spectro/nightwatch/kpno/${NIGHT}/
 
 By-hand startup sequence (bash shell)::
 

--- a/py/desitransfer/nightwatch.py
+++ b/py/desitransfer/nightwatch.py
@@ -114,7 +114,7 @@ def main():
     options = _options()
     _configure_log(options.debug)
     errcount = 0
-    wait = options.sleep*60
+    wait = options.sleep * 60
     source = '/exposures/nightwatch'
     basedir = os.path.join(os.environ['DESI_ROOT'], 'spectro', 'nightwatch')
     kpnodir = os.path.join(basedir, 'kpno')

--- a/py/desitransfer/spacewatch.py
+++ b/py/desitransfer/spacewatch.py
@@ -117,7 +117,8 @@ def download_jpg(files, destination, overwrite=False, test=False):
                 r = requests.get(jpg)
                 if r.status_code == 200:
                     downloaded += 1
-                    timestamp = int(datetime.datetime.strptime(r.headers['Last-Modified'], '%a, %d %b %Y %H:%M:%S %Z').replace(tzinfo=utc).timestamp())
+                    timestamp = int(datetime.datetime.strptime(r.headers['Last-Modified'],
+                                                               '%a, %d %b %Y %H:%M:%S %Z').replace(tzinfo=utc).timestamp())
                     with open(dst_jpg, 'wb') as j:
                         j.write(r.content)
                     os.utime(dst_jpg, (timestamp, timestamp))

--- a/py/desitransfer/test/test_common.py
+++ b/py/desitransfer/test/test_common.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import patch
 from tempfile import TemporaryDirectory
 from ..common import (dt, MST, dir_perm, file_perm, empty_rsync, new_exposures, rsync,
-                      stamp, ensure_scratch, yesterday, today, idle_time)
+                      stamp, ensure_scratch, yesterday, today, idle_time, exclude_years)
 
 
 class FakeDateTime(datetime):
@@ -174,3 +174,11 @@ total size is 118,417,836,324  speedup is 494,367.55
         # mock_datetime.return_value = datetime(2021, 7, 3, 13, 0, 0, tzinfo=MST)
         i = idle_time(tz='US/Pacific')
         self.assertEqual(i, -3600)
+
+    def test_exclude_years(self):
+        """Test exclude statements for a range of years.
+        """
+        last_year = datetime.now().year - 1
+        ex = exclude_years(2018)
+        self.assertEqual(ex[1], '2018*')
+        self.assertEqual(ex[-1], f'{last_year:d}*')

--- a/py/desitransfer/test/test_common.py
+++ b/py/desitransfer/test/test_common.py
@@ -135,7 +135,7 @@ total size is 118,417,836,324  speedup is 494,367.55
         """Test today's date.
         """
         mock_dt.datetime.utcnow.return_value = datetime(2019, 7, 3, 5, 0, 0)
-        mock_dt.timedelta.return_value = timedelta(7/24+0.5)
+        mock_dt.timedelta.return_value = timedelta(7 / 24 + 0.5)
         y = today()
         self.assertEqual(y, '20190702')
 

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -316,7 +316,8 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times' +
+                                              'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync')", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'False'),
                                          call("verify_checksum('%s')", '/desi/root/spectro/staging/raw/20190703/00000127/checksum-00000127.sha256sum'),
@@ -369,7 +370,8 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync')", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'True'),
                                          call("verify_checksum('%s')", '/desi/root/spectro/staging/raw/20190703/00000127/checksum-00000127.sha256sum'),
@@ -416,7 +418,8 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync', failure=True)", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'False'),
                                          call("verify_checksum('%s')", '/desi/root/spectro/staging/raw/20190703/00000127/checksum-00000127.sha256sum'),
@@ -465,7 +468,8 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync')", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'False'),
                                          call("verify_checksum('%s')", '/desi/root/spectro/staging/raw/20190703/00000127/checksum-00000127.sha256sum'),
@@ -519,7 +523,8 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync')", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'False'),
                                          call("verify_checksum('%s')", '/desi/root/spectro/staging/raw/20190703/00000127/checksum-00000127.sha256sum'),
@@ -830,7 +835,8 @@ total size is 118,417,836,324  speedup is 494,367.55
         mock_log.debug.assert_has_calls([call("os.remove('%s')", ls_file),
                                          call("Failed to remove %s because it didn't exist. That's OK.", ls_file),
                                          call("%s -O %s ls -l desi/spectro/data" % (hsi, ls_file)),
-                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
+                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
                                          call("os.chdir('%s')", '/desi/root/spectro/data'),
                                          call('%s -cvhf desi/spectro/data/desi_spectro_data_20190703.tar -H crc:verify=all 20190703' % htar),
                                          call("os.chdir('%s')", self.tmp.name)])
@@ -877,7 +883,8 @@ total size is 118,417,836,324  speedup is 494,367.55
         mock_log.info.assert_has_calls([call('No files appear to have changed in %s.', '20190703')])
         mock_log.debug.assert_has_calls([call("os.remove('%s')", os.path.join(self.tmp.name, 'desi_spectro_data.txt')),
                                          call("%s -O %s ls -l desi/spectro/data" % (hsi, ls_file)),
-                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
+                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001234', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001235', 0o2550),
@@ -900,7 +907,11 @@ total size is 118,417,836,324  speedup is 494,367.55
     @patch('desitransfer.daemon.TransferStatus')
     @patch('desitransfer.daemon.log')
     @patch.object(TransferDaemon, '_configure_log')
-    def test_TransferDaemon_backup_htar_failure(self, mock_cl, mock_log, mock_status, mock_isdir, mock_rm, mock_popen, mock_empty, mock_getcwd, mock_chdir, mock_rsync, mock_chmod, mock_walk):
+    def test_TransferDaemon_backup_htar_failure(self, mock_cl, mock_log,
+                                                mock_status, mock_isdir, mock_rm,
+                                                mock_popen, mock_empty, mock_getcwd,
+                                                mock_chdir, mock_rsync, mock_chmod,
+                                                mock_walk):
         """Test HPSS backup of night with htar failure.
         """
         with patch.dict('os.environ',
@@ -916,7 +927,9 @@ total size is 118,417,836,324  speedup is 494,367.55
                                   ('/desi/root/spectro/data/20190703/00001234', [], ['f1']),
                                   ('/desi/root/spectro/data/20190703/00001235', [], ['f2'])]
         mock_empty.return_value = True
-        mock_popen.return_value = ('1', '', 'Generating .netrc entry...\nMust run interactively to update .netrc\nUnable to update .netrc file\nFor help, see https://docs.nersc.gov/accounts/passwords/\n')
+        mock_popen.return_value = ('1', '', 'Generating .netrc entry...\n' +
+                                   'Must run interactively to update .netrc\n' +
+                                   'Unable to update .netrc file\nFor help, see https://docs.nersc.gov/accounts/passwords/\n')
         mock_getcwd.return_value = 'HOME'
         ls_file = os.path.join(self.tmp.name, 'desi_spectro_data.txt')
         with open(ls_file, 'w') as f:
@@ -928,15 +941,18 @@ total size is 118,417,836,324  speedup is 494,367.55
         mock_log.info.assert_has_calls([call('No files appear to have changed in %s.', '20190703')])
         mock_log.debug.assert_has_calls([call("os.remove('%s')", os.path.join(self.tmp.name, 'desi_spectro_data.txt')),
                                          call("%s -O %s ls -l desi/spectro/data" % (hsi, ls_file)),
-                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
+                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001234', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001235', 0o2550),
                                          call("os.chdir('%s')", '/desi/root/spectro/data'),
                                          call('%s -cvhf desi/spectro/data/desi_spectro_data_20190703.tar -H crc:verify=all 20190703' % htar),
                                          call("os.chdir('%s')", 'HOME')])
-        mock_log.critical.assert_has_calls([call(("HTAR Backup failed! Command was: {0} -cvhf desi/spectro/data/desi_spectro_data_20190703.tar -H crc:verify=all 20190703.".format(htar) +
-                                                  "\nHTAR error message was: Generating .netrc entry...\nMust run interactively to update .netrc\nUnable to update .netrc file\nFor help, see https://docs.nersc.gov/accounts/passwords/\n"))])
+        mock_log.critical.assert_has_calls([call("HTAR Backup failed! Command was: {0} -cvhf desi/spectro/data/desi_spectro_data_20190703.tar -H crc:verify=all 20190703.".format(htar) +
+                                                 "\nHTAR error message was: Generating .netrc entry...\n" +
+                                                 "Must run interactively to update .netrc\n" +
+                                                 "Unable to update .netrc file\nFor help, see https://docs.nersc.gov/accounts/passwords/\n")])
         mock_popen.assert_has_calls([call([htar, '-cvhf', 'desi/spectro/data/desi_spectro_data_20190703.tar', '-H', 'crc:verify=all', '20190703'])])
         mock_status.assert_not_called()
         mock_status.update.assert_not_called()
@@ -953,7 +969,10 @@ total size is 118,417,836,324  speedup is 494,367.55
     @patch('desitransfer.daemon.TransferStatus')
     @patch('desitransfer.daemon.log')
     @patch.object(TransferDaemon, '_configure_log')
-    def test_TransferDaemon_backup_delayed_data(self, mock_cl, mock_log, mock_status, mock_isdir, mock_rm, mock_popen, mock_empty, mock_getcwd, mock_chdir, mock_rsync, mock_chmod, mock_walk):
+    def test_TransferDaemon_backup_delayed_data(self, mock_cl, mock_log, mock_status,
+                                                mock_isdir, mock_rm, mock_popen,
+                                                mock_empty, mock_getcwd, mock_chdir,
+                                                mock_rsync, mock_chmod, mock_walk):
         """Test HPSS backup of night with delayed data.
         """
         with patch.dict('os.environ',
@@ -979,7 +998,8 @@ total size is 118,417,836,324  speedup is 494,367.55
         htar = os.path.join(transfer.conf['common']['hpss'], 'htar')
         mock_log.debug.assert_has_calls([call("os.remove('%s')", os.path.join(self.tmp.name, 'desi_spectro_data.txt')),
                                          call("%s -O %s ls -l desi/spectro/data" % (hsi, ls_file)),
-                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
+                                         call('/bin/rsync --dry-run --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
+                                              'dts:/data/dts/exposures/raw/20190703/ /desi/root/spectro/data/20190703/'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001234', 0o2550),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703/00001235', 0o2550),

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -316,7 +316,7 @@ desi_spectro_data_20190702.tar.idx
         mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/staging/raw/20190703'),
                                          call("os.makedirs('%s', exist_ok=True)", '/desi/root/spectro/data/20190703'),
                                          call("os.chmod('%s', 0o%o)", '/desi/root/spectro/data/20190703', 0o2750),
-                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times' +
+                                         call('/bin/rsync --verbose --recursive --copy-dirlinks --times --omit-dir-times ' +
                                               'dts:/data/dts/exposures/raw/20190703/00000127/ /desi/root/spectro/staging/raw/20190703/00000127/'),
                                          call("status.update('%s', '%s', 'rsync')", '20190703', '00000127'),
                                          call("lock_directory('%s', %s)", '/desi/root/spectro/staging/raw/20190703/00000127', 'False'),

--- a/py/desitransfer/test/test_daemon.py
+++ b/py/desitransfer/test/test_daemon.py
@@ -1045,49 +1045,48 @@ total size is 118,417,836,324  speedup is 494,367.55
         d = os.path.dirname(c)
         with patch('os.listdir') as mock_listdir:
             mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt', 'test_file_2.txt']
-            with patch('desitransfer.daemon.log') as l:
+            with patch('desitransfer.daemon.log') as mock_log:
                 o = verify_checksum(c)
         self.assertEqual(o, "")
-        l.debug.assert_has_calls([call("%s is valid.", os.path.join(d, 'test_file_1.txt')),
-                                  call("%s is valid.", os.path.join(d, 'test_file_2.txt'))])
+        mock_log.debug.assert_has_calls([call("%s is valid.", os.path.join(d, 'test_file_1.txt')),
+                                         call("%s is valid.", os.path.join(d, 'test_file_2.txt'))])
         #
         # Wrong number of files.
         #
         with patch('os.listdir') as mock_listdir:
             mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt']
-            with patch('desitransfer.daemon.log') as l:
+            with patch('desitransfer.daemon.log') as mock_log:
                 o = verify_checksum(c)
         self.assertEqual(o, "1 file(s) listed but not downloaded.\n")
-        l.error.assert_has_calls([call("%s lists %d file(s) that are not present!", c, 1)])
+        mock_log.error.assert_has_calls([call("%s lists %d file(s) that are not present!", c, 1)])
         with patch('os.listdir') as mock_listdir:
             mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt', 'test_file_2.txt', 'test_file_3.txt']
-            with patch('desitransfer.daemon.log') as l:
+            with patch('desitransfer.daemon.log') as mock_log:
                 o = verify_checksum(c)
         self.assertEqual(o, "1 file(s) downloaded but not listed.\ntest_file_3.txt not listed in checksum file.\n")
-        l.error.assert_has_calls([call("%d files are not listed in %s!", 1, c)])
+        mock_log.error.assert_has_calls([call("%d files are not listed in %s!", 1, c)])
         #
         # Bad list of files.
         #
         with patch('os.listdir') as mock_listdir:
             mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt', 'test_file_3.txt']
-            with patch('desitransfer.daemon.log') as l:
+            with patch('desitransfer.daemon.log') as mock_log:
                 o = verify_checksum(c)
         self.assertEqual(o, "test_file_3.txt not listed in checksum file.\n")
-        l.debug.assert_has_calls([call("%s is valid.", os.path.join(d, 'test_file_1.txt'))])
-        l.error.assert_has_calls([call("%s does not appear in %s!", os.path.join(d, 'test_file_3.txt'), c)])
+        mock_log.debug.assert_has_calls([call("%s is valid.", os.path.join(d, 'test_file_1.txt'))])
+        mock_log.error.assert_has_calls([call("%s does not appear in %s!", os.path.join(d, 'test_file_3.txt'), c)])
         #
         # Hack hashlib to produce incorrect checksums.
         #
         with patch('os.listdir') as mock_listdir:
             mock_listdir.return_value = ['t.sha256sum', 'test_file_1.txt', 'test_file_2.txt']
-            with patch('desitransfer.daemon.log') as l:
-                with patch('hashlib.sha256') as h:
-                    # h.sha256 = MagicMock()
-                    h.hexdigest.return_value = 'abcdef'
+            with patch('desitransfer.daemon.log') as mock_log:
+                with patch('hashlib.sha256') as mock_hash:
+                    mock_hash.hexdigest.return_value = 'abcdef'
                     o = verify_checksum(c)
         self.assertEqual(o, "test_file_1.txt had a checksum mismatch.\ntest_file_2.txt had a checksum mismatch.\n")
-        l.error.assert_has_calls([call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_1.txt'), c),
-                                  call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_2.txt'), c)])
+        mock_log.error.assert_has_calls([call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_1.txt'), c),
+                                         call("Checksum mismatch for %s in %s!", os.path.join(d, 'test_file_2.txt'), c)])
 
     @patch('os.walk')
     @patch('os.chmod')

--- a/py/desitransfer/test/test_status.py
+++ b/py/desitransfer/test/test_status.py
@@ -75,17 +75,17 @@ class TestStatus(unittest.TestCase):
         # New directory.
         #
         d = '/desi/spectro/status'
-        with patch('desitransfer.status.log') as l:
-            with patch('os.makedirs') as m:
-                with patch('shutil.copy') as cp:
-                    with patch('shutil.copyfile') as cf:
+        with patch('desitransfer.status.log') as mock_log:
+            with patch('os.makedirs') as mock_makedirs:
+                with patch('shutil.copy') as mock_copy:
+                    with patch('shutil.copyfile') as mock_copyfile:
                         s = TransferStatus(d)
-        l.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", d),
-                                  call("shutil.copyfile('%s', '%s')", h, os.path.join(d, 'index.html')),
-                                  call("shutil.copy('%s', '%s')", j, d)])
-        m.assert_called_once_with(d, exist_ok=True)
-        cp.assert_called_once_with(j, d)
-        cf.assert_called_once_with(h, os.path.join(d, 'index.html'))
+        mock_log.debug.assert_has_calls([call("os.makedirs('%s', exist_ok=True)", d),
+                                         call("shutil.copyfile('%s', '%s')", h, os.path.join(d, 'index.html')),
+                                         call("shutil.copy('%s', '%s')", j, d)])
+        mock_makedirs.assert_called_once_with(d, exist_ok=True)
+        mock_copy.assert_called_once_with(j, d)
+        mock_copyfile.assert_called_once_with(h, os.path.join(d, 'index.html'))
 
     @patch('desitransfer.status.log')
     def test_TransferStatus_handle_malformed_with_log(self, mock_log):

--- a/py/desitransfer/test/test_top_level.py
+++ b/py/desitransfer/test/test_top_level.py
@@ -13,8 +13,7 @@ class TestTopLevel(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.versionre = re.compile(
-                r'([0-9]+!)?([0-9]+)(\.[0-9]+)*((a|b|rc|\.post|\.dev)[0-9]+)?')
+        cls.versionre = re.compile(r'([0-9]+!)?([0-9]+)(\.[0-9]+)*((a|b|rc|\.post|\.dev)[0-9]+)?')
 
     @classmethod
     def tearDownClass(cls):

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -14,6 +14,7 @@ from argparse import ArgumentParser
 from logging.handlers import SMTPHandler
 import requests
 from . import __version__ as dtVersion
+from .common import exclude_years
 from desiutil.log import get_logger
 
 
@@ -61,8 +62,8 @@ dynamic = ['spectro/data',
 includes = {'engineering/focalplane': ["--exclude", "archive", "--exclude", "hwtables", "--exclude", ".ipynb_checkpoints", "--exclude", "*.ipynb"],
             'engineering/focalplane/hwtables': ["--include", "*.csv", "--exclude", "*"],
             'spectro/desi_spectro_calib': ["--exclude", ".svn"],
-            'spectro/data': (' '.join([f'--exclude {y:d}*' for y in range(2018, time.localtime().tm_year)])).split(),
-            'spectro/nightwatch/kpno': (' '.join([f'--exclude {y:d}*' for y in range(2021, time.localtime().tm_year)])).split(),
+            'spectro/data': exclude_years(2018),
+            'spectro/nightwatch/kpno': exclude_years(2021),
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
             'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -62,6 +62,7 @@ includes = {'engineering/focalplane': ["--exclude", "archive", "--exclude", "hwt
             'engineering/focalplane/hwtables': ["--include", "*.csv", "--exclude", "*"],
             'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             'spectro/data': (' '.join([f'--exclude {y:d}*' for y in range(2018, time.localtime().tm_year)])).split(),
+            'spectro/nightwatch/kpno': (' '.join([f'--exclude {y:d}*' for y in range(2021, time.localtime().tm_year)])).split(),
             'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
             'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -59,18 +59,23 @@ dynamic = ['spectro/data',
            'software/CiscoSecureClient']
 
 
-includes = {'engineering/focalplane': ["--exclude", "archive", "--exclude", "hwtables", "--exclude", ".ipynb_checkpoints", "--exclude", "*.ipynb"],
+includes = {'engineering/focalplane': ["--exclude", "archive", "--exclude", "hwtables",
+                                       "--exclude", ".ipynb_checkpoints", "--exclude", "*.ipynb"],
             'engineering/focalplane/hwtables': ["--include", "*.csv", "--exclude", "*"],
             'spectro/desi_spectro_calib': ["--exclude", ".svn"],
             'spectro/data': exclude_years(2018),
             'spectro/nightwatch/kpno': exclude_years(2021),
-            'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic", "--exclude", "exposures", "--exclude", "preproc", "--exclude", "temp", "--exclude", "tiles"],
+            'spectro/redux/daily': ["--exclude", "*.tmp", "--exclude", "attic",
+                                    "--exclude", "exposures", "--exclude", "preproc",
+                                    "--exclude", "temp", "--exclude", "tiles"],
             'spectro/redux/daily/exposures': ["--exclude", "*.tmp"],
-            'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits", "--exclude", "preproc-*.fits.gz"],
+            'spectro/redux/daily/preproc': ["--exclude", "*.tmp", "--exclude", "preproc-*.fits",
+                                            "--exclude", "preproc-*.fits.gz"],
             'spectro/redux/daily/tiles': ["--exclude", "*.tmp", "--exclude", "temp"],
             'spectro/templates/basis_templates': ["--exclude", ".svn", "--exclude", "basis_templates_svn-old"],
             'survey/ops/surveyops/trunk': ["--exclude", ".svn", "--exclude", "cronupdate.log"],
-            'target/catalogs': ["--include", "dr8", "--include", "dr9", "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}
+            'target/catalogs': ["--include", "dr8", "--include", "dr9",
+                                "--include", "gaiadr2", "--include", "subpriority", "--exclude", "*"]}
 
 
 def _configure_log(debug):

--- a/py/desitransfer/tucson.py
+++ b/py/desitransfer/tucson.py
@@ -241,7 +241,7 @@ def main():
         for s in suffix:
             if options.sleep.endswith(s):
                 try:
-                    sleepy_time = int(options.sleep[0:-1])*suffix[s]
+                    sleepy_time = int(options.sleep[0:-1]) * suffix[s]
                 except ValueError:
                     log.error("Invalid value for sleep interval: '%s'!", options.sleep)
                     return 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,6 +116,7 @@ exclude_lines =
 # ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504
 #
 # These are the explicitly ignored styles:
-# - E501: line too long (82 > 79 characters)
 # - W504: line break after binary operator
-ignore = E501, W504
+# - E501: not ignored, but 190 will eventually be reduced.
+max-line-length = 190
+ignore = W504

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,9 +115,7 @@ exclude_lines =
 # These are normally ignored by default:
 # ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504
 #
-# In addition to the default set we add:
+# These are the explicitly ignored styles:
 # - E501: line too long (82 > 79 characters)
-# - E731: do not assign a lambda expression, use a def
-# - E741: do not use variables named 'l', 'O', or 'I' -- because, for example,
-#   'l' might refer to Galactic longitude.
-ignore = E121, E123, E126, E133, E226, E241, E242, E501, E704, E731, E741, W503, W504
+# - W504: line break after binary operator
+ignore = E501, W504


### PR DESCRIPTION
The copy of nightwatch data, specifically KPNO nightwatch data, is slow because it had been trying to examine every night since 2021 for changes. This PR restricts mirroring to the current year.

Since this is non-controversial, I will self-merge after an operational test.