### PR TITLE
Add morning 'endofnight' transfer

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,12 @@
 Change Log
 ==========
 
-1.0.4 (unreleased)
+1.0.4 (2024-10-23)
 ------------------
 
-* No changes yet.
+* Add ``engineering/focalplane/endofnight`` to morning engineering transfers (PR `#63`_).
+
+.. _`#63`: https://github.com/desihub/desitransfer/pull/63
 
 1.0.3 (2024-09-26)
 ------------------

--- a/py/desitransfer/daily.py
+++ b/py/desitransfer/daily.py
@@ -130,7 +130,9 @@ def _config(timeframe):
     if timeframe == 'morning':
         return [DailyDirectory('/software/www2/html/nightlogs',
                                os.path.join(survey, 'ops', 'nightlogs'),
-                               extra=['--include-from', nightlog_include, '--exclude', '*']),]
+                               extra=['--include-from', nightlog_include, '--exclude', '*']),
+                DailyDirectory('/data/focalplane/endofnight',
+                               os.path.join(engineering, 'focalplane', 'endofnight'))]
     else:
         return [DailyDirectory('/data/dts/exposures/lost+found',
                                os.path.join(spectro, 'staging', 'lost+found'),


### PR DESCRIPTION
This PR adds `endofnight/` to morning engineering data transfers.