### PR TITLE
Exclude rrdetails files at Utah

### DIFF
--- a/bin/desi_utah_transfer.sh
+++ b/bin/desi_utah_transfer.sh
@@ -163,7 +163,7 @@ for d in ${directories[*]}; do
         spectro/redux/daily/calibnight) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_calibnight.txt --exclude *" ;;
         spectro/redux/daily/exposures) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_exposures.txt --exclude *" ;;
         spectro/redux/daily/preproc) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_preproc.txt --exclude *" ;;
-        spectro/redux/daily/tiles/archive) priority=''; exclude="--delete-excluded --exclude rrdetails-*.h5" ;;
+        spectro/redux/daily/tiles/archive) priority=''; exclude="--exclude rrdetails-*.h5" ;;
         spectro/redux/daily/tiles/cumulative) priority='nice'; exclude="--delete-excluded --files-from ${DESI_ROOT}/spectro/redux/daily_tiles_cumulative.txt" ;;
         *) priority=''; exclude='' ;;
     esac

--- a/bin/desi_utah_transfer.sh
+++ b/bin/desi_utah_transfer.sh
@@ -15,7 +15,7 @@ function usage() {
     echo "     -A = Do NOT start a sync of daily/tiles/archive."
     echo "     -h = Print this message and exit."
     echo "     -R = Do NOT check for running jobs before starting new ones."
-    echo "     -T = Do NOT execute commands via the `time` command."
+    echo "     -T = Do NOT execute commands via the 'time' command."
     echo "     -t = Test mode.  Do not make any changes. Implies -v."
     echo "     -v = Verbose mode. Print extra information."
     echo ""

--- a/bin/desi_utah_transfer.sh
+++ b/bin/desi_utah_transfer.sh
@@ -163,6 +163,7 @@ for d in ${directories[*]}; do
         spectro/redux/daily/calibnight) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_calibnight.txt --exclude *" ;;
         spectro/redux/daily/exposures) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_exposures.txt --exclude *" ;;
         spectro/redux/daily/preproc) priority='nice'; exclude="--delete-excluded --include-from ${DESI_ROOT}/spectro/redux/daily_preproc.txt --exclude *" ;;
+        spectro/redux/daily/tiles/archive) priority=''; exclude="--delete-excluded --exclude rrdetails-*.h5" ;;
         spectro/redux/daily/tiles/cumulative) priority='nice'; exclude="--delete-excluded --files-from ${DESI_ROOT}/spectro/redux/daily_tiles_cumulative.txt" ;;
         *) priority=''; exclude='' ;;
     esac

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,11 @@ Change Log
 1.0.6 (unreleased)
 ------------------
 
-* Ignore ``rrdetails-*.h5`` files at Utah.
+* Ignore ``rrdetails-*.h5`` files at Utah (PR `#70`_).
 * Add additional functionality to Tucson and Utah mirror scripts (PR `#69`_).
 
 .. _`#69`: https://github.com/desihub/desitransfer/pull/69
+.. _`#70`: https://github.com/desihub/desitransfer/pull/70
 
 1.0.5 (2025-10-10)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ Change Log
 1.0.6 (unreleased)
 ------------------
 
+* Ignore ``rrdetails-*.h5`` files at Utah.
 * Add additional functionality to Tucson and Utah mirror scripts (PR `#69`_).
 
 .. _`#69`: https://github.com/desihub/desitransfer/pull/69


### PR DESCRIPTION
This PR excludes `rrdetails-*.h5` files from Utah, to save disk space.